### PR TITLE
First prototype of seeding framework refactoring (only for preview, DO NOT MERGE)

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -47,6 +47,105 @@ def customiseFor14833(process):
                 producer.includeME0 = cms.bool(False)
     return process
 
+def customiseForXXXXX(process):
+    from RecoTracker.TkTrackingRegions.globalTrackingRegionFromBeamSpot_cfi import globalTrackingRegionFromBeamSpot as _globalTrackingRegionFromBeamSpot
+    from RecoTracker.TkSeedGenerator.clusterCheckerEDProducer_cff import clusterCheckerEDProducer as _clusterCheckerEDProducer
+    from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
+    from RecoPixelVertexing.PixelTriplets.pixelTripletHLTEDProducer_cfi import pixelTripletHLTEDProducer as _pixelTripletHLTEDProducer
+    from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_cfi import seedCreatorFromRegionConsecutiveHitsEDProducer as _seedCreatorFromRegionConsecutiveHitsEDProducer
+    def _copy(old, new, skip=[]):
+        skipSet = set(skip)
+        for key in old.parameterNames_():
+            if key not in skipSet:
+                setattr(new, key, getattr(old, key))
+
+    # Bit of a hack to replace a module with another, but works
+    modifier = cms.Modifier()
+    modifier._setChosen()
+
+    for producer in producers_by_type(process, "SeedGeneratorFromRegionHitsEDProducer"):
+        if producer.OrderedHitsFactoryPSet.ComponentName.value() != "StandardHitTripletGenerator":
+            continue
+        if producer.OrderedHitsFactoryPSet.GeneratorPSet.ComponentName.value() != "PixelTripletHLTGenerator":
+            continue
+        if producer.RegionFactoryPSet.ComponentName.value() != "GlobalRegionProducerFromBeamSpot":
+            continue
+
+        label = producer.label()
+        if "Seeds" in label:
+            regionLabel = label.replace("Seeds", "TrackingRegions")
+            clusterCheckLabel = label.replace("Seeds", "ClusterCheck")
+            doubletLabel = label.replace("Seeds", "HitDoublets")
+            tripletLabel = label.replace("Seeds", "HitTriplets")
+        else:
+            regionLabel = label + "TrackingRegions"
+            clusterCheckLabel = label + "ClusterCheck"
+            doubletLabel = label + "HitPairs"
+            tripletLabel = label + "HitTriplets"
+
+        # Construct new producers
+        regionProducer = _globalTrackingRegionFromBeamSpot.clone()
+        regionProducer.RegionPSet = producer.RegionFactoryPSet.RegionPSet
+
+        clusterCheckProducer = _clusterCheckerEDProducer.clone()
+        _copy(producer.ClusterCheckPSet, clusterCheckProducer)
+
+        doubletProducer = _hitPairEDProducer.clone(
+            seedingLayers = producer.OrderedHitsFactoryPSet.SeedingLayers.value(),
+            trackingRegions = regionLabel,
+            clusterCheck = clusterCheckLabel,
+            produceIntermediateHitDoublets = True,
+        )
+
+        tripletProducer = _pixelTripletHLTEDProducer.clone(
+            doublets = doubletLabel,
+            produceSeedingHitSets = True,
+        )
+        _copy(producer.OrderedHitsFactoryPSet.GeneratorPSet, tripletProducer, skip=["ComponentName"])
+
+        seedCreatorPSet = producer.SeedCreatorPSet
+        if hasattr(seedCreatorPSet, "refToPSet_"):
+            seedCreatorPSet = getattr(process, seedCreatorPSet.refToPSet_.value())
+
+        seedProducer = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
+            seedingHitSets = tripletLabel,
+        )
+        _copy(seedCreatorPSet, seedProducer, skip=["ComponentName"])
+
+        # Set new producers to process
+        setattr(process, regionLabel, regionProducer)
+        setattr(process, clusterCheckLabel, clusterCheckProducer)
+        setattr(process, doubletLabel, doubletProducer)
+        setattr(process, tripletLabel, tripletProducer)
+        modifier.toReplaceWith(producer, seedProducer)
+
+        # Modify sequences (also paths to be sure, altough in practice
+        # the seeding modules should be only in sequences in HLT?)
+        for seqs in [process.sequences_(), process.paths_()]:
+            for seqName, seq in seqs.iteritems():
+                # Is there really no simpler way to add
+                # regionProducer+doubletProducer+tripletProducer
+                # before producer in the sequence?
+                #
+                # cms.Sequence.replace() would look much simpler, but
+                # it traverses the contained sequences too, leading to
+                # multiple replaces as we already loop over all
+                # sequences of a cms.Process, and also expands the
+                # contained sequences if a replacement occurs there.
+                try:
+                    index = seq.index(producer)
+                except:
+                    continue
+
+                # Inserted on reverse order, succeeding module will be
+                # inserted before preceding one
+                seq.insert(index, tripletProducer)
+                seq.insert(index, doubletProducer)
+                seq.insert(index, clusterCheckProducer)
+                seq.insert(index, regionProducer)
+
+    return process
+
 #
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
@@ -58,6 +157,7 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
         process = customiseFor14356(process)
         process = customiseFor13753(process)
         process = customiseFor14833(process)
+        process = customiseForXXXXX(process)
 #       process = customiseFor12718(process)
         pass
 

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -70,6 +70,8 @@ def customiseForXXXXX(process):
             continue
         if producer.RegionFactoryPSet.ComponentName.value() != "GlobalRegionProducerFromBeamSpot":
             continue
+        if producer.SeedCreatorPSet.ComponentName.value() != "SeedFromConsecutiveHitsCreator":
+            continue
 
         label = producer.label()
         if "Seeds" in label:

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/PixelTripletLowPtGenerator.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/PixelTripletLowPtGenerator.cc
@@ -100,7 +100,7 @@ void PixelTripletLowPtGenerator::hitTriplets(
   // Set aliases
   const RecHitsSortedInPhi **thirdHitMap = new const RecHitsSortedInPhi*[size]; 
   for(int il=0; il<size; il++)
-    thirdHitMap[il] = &(*theLayerCache)(thirdLayers[il], region, ev, es);
+    thirdHitMap[il] = &(*theLayerCache)(thirdLayers[il], region, es);
 
   // Get tracker
   getTracker(es);

--- a/RecoPixelVertexing/PixelTriplets/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTriplets/BuildFile.xml
@@ -1,3 +1,4 @@
+<use   name="root"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/PluginManager"/>

--- a/RecoPixelVertexing/PixelTriplets/interface/HitTripletEDProducerT.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/HitTripletEDProducerT.h
@@ -78,15 +78,24 @@ void HitTripletEDProducerT<T_HitTripletGenerator>::produce(edm::Event& iEvent, c
   }
 
   std::unique_ptr<RegionsSeedingHitSets> seedingHitSets;
-  if(produceSeedingHitSets_) {
-    seedingHitSets = std::make_unique<RegionsSeedingHitSets>();
-    seedingHitSets->reserve(regionDoublets.regionSize(), localRA_.upper());
-  }
   std::unique_ptr<IntermediateHitTriplets> intermediateHitTriplets;
-  if(produceIntermediateHitTriplets_) {
+  if(produceSeedingHitSets_)
+    seedingHitSets = std::make_unique<RegionsSeedingHitSets>();
+  if(produceIntermediateHitTriplets_)
     intermediateHitTriplets = std::make_unique<IntermediateHitTriplets>(&seedingLayerHits);
-    intermediateHitTriplets->reserve(regionDoublets.regionSize(), seedingLayerHits.size(), localRA_.upper());
+
+  if(regionDoublets.empty()) {
+    if(produceSeedingHitSets_)
+      iEvent.put(std::move(seedingHitSets));
+    if(produceIntermediateHitTriplets_)
+      iEvent.put(std::move(intermediateHitTriplets));
+    return;
   }
+
+  if(produceSeedingHitSets_)
+    seedingHitSets->reserve(regionDoublets.regionSize(), localRA_.upper());
+  if(produceIntermediateHitTriplets_)
+    intermediateHitTriplets->reserve(regionDoublets.regionSize(), seedingLayerHits.size(), localRA_.upper());
 
   // match-making of pair and triplet layers
   std::vector<LayerTriplets::LayerSetAndLayers> trilayers = LayerTriplets::layers(seedingLayerHits);

--- a/RecoPixelVertexing/PixelTriplets/interface/HitTripletEDProducerT.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/HitTripletEDProducerT.h
@@ -90,8 +90,9 @@ void HitTripletEDProducerT<T_HitTripletGenerator>::produce(edm::Event& iEvent, c
 
   // match-making of pair and triplet layers
   std::vector<LayerTriplets::LayerSetAndLayers> trilayers = LayerTriplets::layers(seedingLayerHits);
-  std::vector<unsigned int> thirdLayerHitBeginIndices;
-  thirdLayerHitBeginIndices.reserve(3); // Yes, vector is a bit overkill as there can be at most 3 3rd layers for a doublet. But better be consistent and migrate later everything to e.g. std::array or edm::VecArray. Except with phase1 there can be more than 3 3rd layers...
+  std::vector<int> tripletLastLayerIndex;
+  tripletLastLayerIndex.reserve(localRA_.upper());
+  std::vector<size_t> tripletPermutation; // used to sort the triplets according to their last-hit layer
 
   OrderedHitTriplets triplets;
   triplets.reserve(localRA_.upper());
@@ -117,12 +118,13 @@ void HitTripletEDProducerT<T_HitTripletGenerator>::produce(edm::Event& iEvent, c
         }
         throw exp;
       }
+      const auto& thirdLayers = found->second;
 
       LayerHitMapCache hitCache;
       hitCache.extend(layerPair.cache());
 
-      thirdLayerHitBeginIndices.clear();
-      generator_.hitTriplets(region, triplets, iEvent, iSetup, layerPair.doublets(), found->second, &thirdLayerHitBeginIndices, hitCache);
+      tripletLastLayerIndex.clear();
+      generator_.hitTriplets(region, triplets, iEvent, iSetup, layerPair.doublets(), thirdLayers, &tripletLastLayerIndex, hitCache);
       if(triplets.empty())
         continue;
 
@@ -133,18 +135,20 @@ void HitTripletEDProducerT<T_HitTripletGenerator>::produce(edm::Event& iEvent, c
         }
       }
       if(produceIntermediateHitTriplets_) {
-        if(thirdLayerHitBeginIndices.size() != trilayers.size()) {
-          throw cms::Exception("LogicError") << "thirdLayerHitBeginIndices.size() " << thirdLayerHitBeginIndices.size()
-                                             << " trilayers.size() " << trilayers.size();
+        if(tripletLastLayerIndex.size() != triplets.size()) {
+          throw cms::Exception("LogicError") << "tripletLastLayerIndex.size() " << tripletLastLayerIndex.size()
+                                             << " triplets.size() " << triplets.size();
         }
-        for(size_t i=0, size=trilayers.size(); i<size; ++i) {
-          const size_t begin = thirdLayerHitBeginIndices[i];
-          const size_t end = i<size ? thirdLayerHitBeginIndices[i+1] : triplets.size();
-          intermediateHitTriplets->addTriplets(found->first, found->second[i],
-                                               std::next(triplets.begin(), begin), std::next(triplets.begin(), end),
-                                               std::move(hitCache));
-        }
+        tripletPermutation.resize(tripletLastLayerIndex.size());
+        std::iota(tripletPermutation.begin(), tripletPermutation.end(), 0); // assign 0,1,2,...,N
+        std::stable_sort(tripletPermutation.begin(), tripletPermutation.end(), [&](size_t i, size_t j) {
+            return tripletLastLayerIndex[i] < tripletLastLayerIndex[j];
+          });
+
+        intermediateHitTriplets->addTriplets(thirdLayers, triplets, tripletLastLayerIndex, tripletPermutation);
       }
+
+      triplets.clear();
     }
   }
   localRA_.update(triplets_total);

--- a/RecoPixelVertexing/PixelTriplets/interface/HitTripletEDProducerT.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/HitTripletEDProducerT.h
@@ -1,0 +1,159 @@
+#ifndef RecoPixelVertexing_PixelTriplets_HitTripletEDProducerT_H
+#define RecoPixelVertexing_PixelTriplets_HitTripletEDProducerT_H
+
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Utilities/interface/RunningAverage.h"
+
+#include "RecoTracker/TkHitPairs/interface/IntermediateHitDoublets.h"
+#include "RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/OrderedHitTriplets.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/IntermediateHitTriplets.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/LayerTriplets.h"
+
+template <typename T_HitTripletGenerator>
+class HitTripletEDProducerT: public edm::stream::EDProducer<> {
+public:
+  HitTripletEDProducerT(const edm::ParameterSet& iConfig);
+  ~HitTripletEDProducerT() = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  virtual void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+
+private:
+  edm::EDGetTokenT<IntermediateHitDoublets> doubletToken_;
+
+  edm::RunningAverage localRA_;
+
+  T_HitTripletGenerator generator_;
+
+  const bool produceSeedingHitSets_;
+  const bool produceIntermediateHitTriplets_;
+};
+
+template <typename T_HitTripletGenerator>
+HitTripletEDProducerT<T_HitTripletGenerator>::HitTripletEDProducerT(const edm::ParameterSet& iConfig):
+  doubletToken_(consumes<IntermediateHitDoublets>(iConfig.getParameter<edm::InputTag>("doublets"))),
+  generator_(iConfig, consumesCollector()),
+  produceSeedingHitSets_(iConfig.getParameter<bool>("produceSeedingHitSets")),
+  produceIntermediateHitTriplets_(iConfig.getParameter<bool>("produceIntermediateHitTriplets"))
+{
+  if(!produceIntermediateHitTriplets_ && !produceSeedingHitSets_)
+    throw cms::Exception("Configuration") << "HitTripletEDProducerT requires either produceIntermediateHitTriplets or produceSeedingHitSets to be True. If neither are needed, just remove this module from your sequence/path as it doesn't do anything useful";
+  if(produceSeedingHitSets_)
+    produces<std::vector<SeedingHitSet> >();
+  if(produceIntermediateHitTriplets_)
+    produces<IntermediateHitTriplets>();
+}
+
+template <typename T_HitTripletGenerator>
+void HitTripletEDProducerT<T_HitTripletGenerator>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add<edm::InputTag>("doublets", edm::InputTag("hitPairEDProducer"));
+  desc.add<bool>("produceSeedingHitSets", false);
+  desc.add<bool>("produceIntermediateHitTriplets", false);
+
+  T_HitTripletGenerator::fillDescriptions(desc);
+
+  descriptions.add(T_HitTripletGenerator::fillDescriptionsLabel(), desc);
+}
+
+template <typename T_HitTripletGenerator>
+void HitTripletEDProducerT<T_HitTripletGenerator>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<IntermediateHitDoublets> hdoublets;
+  iEvent.getByToken(doubletToken_, hdoublets);
+  const auto& regionDoublets = *hdoublets;
+
+  const SeedingLayerSetsHits& seedingLayerHits = regionDoublets.seedingLayerHits();
+  if(seedingLayerHits.numberOfLayersInSet() < 3) {
+    throw cms::Exception("Configuration") << "HitTripletEDProducerT expects SeedingLayerSetsHits::numberOfLayersInSet() to be >= 3, got " << seedingLayerHits.numberOfLayersInSet();
+  }
+
+  std::unique_ptr<std::vector<SeedingHitSet> > seedingHitSets;
+  if(produceSeedingHitSets_) {
+    seedingHitSets = std::make_unique<std::vector<SeedingHitSet> >();
+    seedingHitSets->reserve(localRA_.upper());
+  }
+  std::unique_ptr<IntermediateHitTriplets> intermediateHitTriplets;
+  if(produceIntermediateHitTriplets_) {
+    intermediateHitTriplets = std::make_unique<IntermediateHitTriplets>(&seedingLayerHits);
+    intermediateHitTriplets->reserve(regionDoublets.regionSize(), seedingLayerHits.size(), localRA_.upper());
+  }
+
+  // match-making of pair and triplet layers
+  std::vector<LayerTriplets::LayerSetAndLayers> trilayers = LayerTriplets::layers(seedingLayerHits);
+  std::vector<unsigned int> thirdLayerHitBeginIndices;
+  thirdLayerHitBeginIndices.reserve(3); // Yes, vector is a bit overkill as there can be at most 3 3rd layers for a doublet. But better be consistent and migrate later everything to e.g. std::array or edm::VecArray. Except with phase1 there can be more than 3 3rd layers...
+
+  OrderedHitTriplets triplets;
+  triplets.reserve(localRA_.upper());
+  size_t triplets_total = 0;
+
+  for(const auto& regionLayerPairs: regionDoublets) {
+    const TrackingRegion& region = regionLayerPairs.region();
+    intermediateHitTriplets->beginRegion(&region);
+
+    for(const auto& layerPair: regionLayerPairs) {
+      auto found = std::find_if(trilayers.begin(), trilayers.end(), [&](const LayerTriplets::LayerSetAndLayers& a) {
+          return a.first[0].index() == layerPair.innerLayerIndex() && a.first[1].index() == layerPair.outerLayerIndex();
+        });
+      if(found == trilayers.end()) {
+        auto exp = cms::Exception("LogicError") << "Did not find the layer pair from vector<pair+third layers>. This is a sign of some internal inconsistency\n";
+        exp << "I was looking for layer pair " << layerPair.innerLayerIndex() << "," << layerPair.outerLayerIndex() << ". Triplets have the following pairs:\n";
+        for(const auto& a: trilayers) {
+          exp << " " << a.first[0].index() << "," << a.first[1].index() << ": 3rd layers";
+          for(const auto& b: a.second) {
+            exp << " " << b.index();
+          }
+          exp << "\n";
+        }
+        throw exp;
+      }
+
+      LayerHitMapCache hitCache;
+      hitCache.extend(layerPair.cache());
+
+      thirdLayerHitBeginIndices.clear();
+      generator_.hitTriplets(region, triplets, iEvent, iSetup, layerPair.doublets(), found->second, &thirdLayerHitBeginIndices, hitCache);
+      if(triplets.empty())
+        continue;
+
+      triplets_total += triplets.size();
+      if(produceSeedingHitSets_) {
+        for(const auto& trpl: triplets) {
+          seedingHitSets->emplace_back(trpl.inner(), trpl.middle(), trpl.outer());
+        }
+      }
+      if(produceIntermediateHitTriplets_) {
+        if(thirdLayerHitBeginIndices.size() != trilayers.size()) {
+          throw cms::Exception("LogicError") << "thirdLayerHitBeginIndices.size() " << thirdLayerHitBeginIndices.size()
+                                             << " trilayers.size() " << trilayers.size();
+        }
+        for(size_t i=0, size=trilayers.size(); i<size; ++i) {
+          const size_t begin = thirdLayerHitBeginIndices[i];
+          const size_t end = i<size ? thirdLayerHitBeginIndices[i+1] : triplets.size();
+          intermediateHitTriplets->addTriplets(found->first, found->second[i],
+                                               std::next(triplets.begin(), begin), std::next(triplets.begin(), end),
+                                               std::move(hitCache));
+        }
+      }
+    }
+  }
+  localRA_.update(triplets_total);
+
+  if(produceSeedingHitSets_)
+    iEvent.put(std::move(seedingHitSets));
+  if(produceIntermediateHitTriplets_)
+    iEvent.put(std::move(intermediateHitTriplets));
+}
+
+
+#endif

--- a/RecoPixelVertexing/PixelTriplets/interface/HitTripletEDProducerT.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/HitTripletEDProducerT.h
@@ -12,7 +12,7 @@
 #include "FWCore/Utilities/interface/RunningAverage.h"
 
 #include "RecoTracker/TkHitPairs/interface/IntermediateHitDoublets.h"
-#include "RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h"
+#include "RecoTracker/TkHitPairs/interface/RegionsSeedingHitSets.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/OrderedHitTriplets.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/IntermediateHitTriplets.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/LayerTriplets.h"
@@ -48,7 +48,7 @@ HitTripletEDProducerT<T_HitTripletGenerator>::HitTripletEDProducerT(const edm::P
   if(!produceIntermediateHitTriplets_ && !produceSeedingHitSets_)
     throw cms::Exception("Configuration") << "HitTripletEDProducerT requires either produceIntermediateHitTriplets or produceSeedingHitSets to be True. If neither are needed, just remove this module from your sequence/path as it doesn't do anything useful";
   if(produceSeedingHitSets_)
-    produces<std::vector<SeedingHitSet> >();
+    produces<RegionsSeedingHitSets>();
   if(produceIntermediateHitTriplets_)
     produces<IntermediateHitTriplets>();
 }
@@ -77,10 +77,10 @@ void HitTripletEDProducerT<T_HitTripletGenerator>::produce(edm::Event& iEvent, c
     throw cms::Exception("Configuration") << "HitTripletEDProducerT expects SeedingLayerSetsHits::numberOfLayersInSet() to be >= 3, got " << seedingLayerHits.numberOfLayersInSet();
   }
 
-  std::unique_ptr<std::vector<SeedingHitSet> > seedingHitSets;
+  std::unique_ptr<RegionsSeedingHitSets> seedingHitSets;
   if(produceSeedingHitSets_) {
-    seedingHitSets = std::make_unique<std::vector<SeedingHitSet> >();
-    seedingHitSets->reserve(localRA_.upper());
+    seedingHitSets = std::make_unique<RegionsSeedingHitSets>();
+    seedingHitSets->reserve(regionDoublets.regionSize(), localRA_.upper());
   }
   std::unique_ptr<IntermediateHitTriplets> intermediateHitTriplets;
   if(produceIntermediateHitTriplets_) {
@@ -102,7 +102,14 @@ void HitTripletEDProducerT<T_HitTripletGenerator>::produce(edm::Event& iEvent, c
 
   for(const auto& regionLayerPairs: regionDoublets) {
     const TrackingRegion& region = regionLayerPairs.region();
-    intermediateHitTriplets->beginRegion(&region);
+
+    auto seedingHitSetsFiller = RegionsSeedingHitSets::dummyFiller();
+    if(produceSeedingHitSets_) {
+      seedingHitSetsFiller = seedingHitSets->beginRegion(&region);
+    }
+    if(produceIntermediateHitTriplets_) {
+      intermediateHitTriplets->beginRegion(&region);
+    }
 
     LogTrace("HitTripletEDProducer") << " starting region";
 
@@ -146,7 +153,7 @@ void HitTripletEDProducerT<T_HitTripletGenerator>::produce(edm::Event& iEvent, c
       triplets_total += triplets.size();
       if(produceSeedingHitSets_) {
         for(const auto& trpl: triplets) {
-          seedingHitSets->emplace_back(trpl.inner(), trpl.middle(), trpl.outer());
+          seedingHitSetsFiller.emplace_back(trpl.inner(), trpl.middle(), trpl.outer());
         }
       }
       if(produceIntermediateHitTriplets_) {

--- a/RecoPixelVertexing/PixelTriplets/interface/HitTripletEDProducerT.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/HitTripletEDProducerT.h
@@ -98,11 +98,17 @@ void HitTripletEDProducerT<T_HitTripletGenerator>::produce(edm::Event& iEvent, c
   triplets.reserve(localRA_.upper());
   size_t triplets_total = 0;
 
+  LogDebug("HitTripletEDProducer") << "Creating triplets for " << regionDoublets.regionSize() << " regions, and " << trilayers.size() << " pair+3rd layers from " << regionDoublets.layerPairsSize() << " layer pairs";
+
   for(const auto& regionLayerPairs: regionDoublets) {
     const TrackingRegion& region = regionLayerPairs.region();
     intermediateHitTriplets->beginRegion(&region);
 
+    LogTrace("HitTripletEDProducer") << " starting region";
+
     for(const auto& layerPair: regionLayerPairs) {
+      LogTrace("HitTripletEDProducer") << "  starting layer pair " << layerPair.innerLayerIndex() << "," << layerPair.outerLayerIndex();
+
       auto found = std::find_if(trilayers.begin(), trilayers.end(), [&](const LayerTriplets::LayerSetAndLayers& a) {
           return a.first[0].index() == layerPair.innerLayerIndex() && a.first[1].index() == layerPair.outerLayerIndex();
         });
@@ -122,11 +128,20 @@ void HitTripletEDProducerT<T_HitTripletGenerator>::produce(edm::Event& iEvent, c
 
       LayerHitMapCache hitCache;
       hitCache.extend(layerPair.cache());
+      LayerHitMapCache *hitCachePtr = &hitCache;
+      if(produceIntermediateHitTriplets_) {
+        hitCachePtr = intermediateHitTriplets->beginPair(layerPair.layerPair(), std::move(hitCache));
+      }
 
       tripletLastLayerIndex.clear();
-      generator_.hitTriplets(region, triplets, iEvent, iSetup, layerPair.doublets(), thirdLayers, &tripletLastLayerIndex, hitCache);
-      if(triplets.empty())
-        continue;
+      generator_.hitTriplets(region, triplets, iEvent, iSetup, layerPair.doublets(), thirdLayers, &tripletLastLayerIndex, *hitCachePtr);
+
+#ifdef EDM_ML_DEBUG
+      LogTrace("HitTripletEDProducer") << "  created " << triplets.size() << " triplets for layer pair " << layerPair.innerLayerIndex() << "," << layerPair.outerLayerIndex() << " and 3rd layers";
+      for(const auto& l: thirdLayers) {
+        LogTrace("HitTripletEDProducer") << "   " << l.index();
+      }
+#endif
 
       triplets_total += triplets.size();
       if(produceSeedingHitSets_) {
@@ -145,6 +160,7 @@ void HitTripletEDProducerT<T_HitTripletGenerator>::produce(edm::Event& iEvent, c
             return tripletLastLayerIndex[i] < tripletLastLayerIndex[j];
           });
 
+        // empty triplets need to propagate here
         intermediateHitTriplets->addTriplets(thirdLayers, triplets, tripletLastLayerIndex, tripletPermutation);
       }
 

--- a/RecoPixelVertexing/PixelTriplets/interface/HitTripletGeneratorFromPairAndLayers.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/HitTripletGeneratorFromPairAndLayers.h
@@ -12,7 +12,7 @@
 #include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
 #include "RecoTracker/TkHitPairs/interface/LayerHitMapCache.h"
 
-namespace edm { class ParameterSet; class Event; class EventSetup; class ConsumesCollector; }
+namespace edm { class ParameterSet; class Event; class EventSetup; class ConsumesCollector; class ParameterSetDescription;}
 class TrackingRegion;
 class HitPairGeneratorFromLayerPair;
 
@@ -24,6 +24,8 @@ public:
   explicit HitTripletGeneratorFromPairAndLayers(unsigned int maxElement=0);
   explicit HitTripletGeneratorFromPairAndLayers(const edm::ParameterSet& pset);
   virtual ~HitTripletGeneratorFromPairAndLayers();
+
+  static void fillDescriptions(edm::ParameterSetDescription& desc);
 
   void init( std::unique_ptr<HitPairGeneratorFromLayerPair>&& pairs, LayerCacheType* layerCache);
 

--- a/RecoPixelVertexing/PixelTriplets/interface/IntermediateHitTriplets.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/IntermediateHitTriplets.h
@@ -1,0 +1,82 @@
+#ifndef RecoPixelVertexing_PixelTriplets_IntermediateHitTriplets_h
+#define RecoPixelVertexing_PixelTriplets_IntermediateHitTriplets_h
+
+#include "RecoTracker/TkHitPairs/interface/LayerHitMapCache.h"
+#include "RecoTracker/TkHitPairs/interface/IntermediateHitDoublets.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/OrderedHitTriplets.h"
+
+/**
+ * Simple container of temporary information delivered from hit triplet
+ * generator to hit quadruplet generator via edm::Event.
+ */
+class IntermediateHitTriplets {
+public:
+  using LayerTriplet = std::tuple<SeedingLayerSetsHits::LayerIndex,
+                                  SeedingLayerSetsHits::LayerIndex,
+                                  SeedingLayerSetsHits::LayerIndex>;
+  using RegionIndex = ihd::RegionIndex;
+
+  ////////////////////
+
+  class LayerTripletHitIndex {
+  public:
+    LayerTripletHitIndex(const SeedingLayerSetsHits::SeedingLayerSet& layerPair, const SeedingLayerSetsHits::SeedingLayer& thirdLayer,
+                         size_t begin, LayerHitMapCache&& cache):
+      layerTriplet_(layerPair[0].index(), layerPair[1].index(), thirdLayer.index()),
+      hitsBegin_(begin),
+      cache_(std::move(cache))
+    {}
+
+  private:
+    LayerTriplet layerTriplet_;
+    size_t hitsBegin_;
+    LayerHitMapCache cache_;
+  };
+
+  ////////////////////
+
+  IntermediateHitTriplets(): seedingLayers_(nullptr) {}
+  explicit IntermediateHitTriplets(const SeedingLayerSetsHits *seedingLayers): seedingLayers_(seedingLayers) {}
+  IntermediateHitTriplets(const IntermediateHitTriplets& rh); // only to make ROOT dictionary generation happy
+  ~IntermediateHitTriplets() = default;
+
+  void swap(IntermediateHitTriplets& rh) {
+    std::swap(seedingLayers_, rh.seedingLayers_);
+    std::swap(regions_, rh.regions_);
+    std::swap(layerTriplets_, rh.layerTriplets_);
+    std::swap(hitTriplets_, rh.hitTriplets_);
+  }
+
+  void reserve(size_t nregions, size_t nlayersets, size_t ntriplets) {
+    regions_.reserve(nregions);
+    layerTriplets_.reserve(nregions*nlayersets);
+    hitTriplets_.reserve(ntriplets);
+  }
+
+  void shrink_to_fit() {
+    regions_.shrink_to_fit();
+    layerTriplets_.shrink_to_fit();
+    hitTriplets_.shrink_to_fit();
+  }
+
+  void beginRegion(const TrackingRegion *region) {
+    regions_.emplace_back(region, layerTriplets_.size());
+  }
+
+  void addTriplets(const SeedingLayerSetsHits::SeedingLayerSet& layerPair, const SeedingLayerSetsHits::SeedingLayer& thirdLayer,
+                   OrderedHitTriplets::iterator hitTripletsBegin, OrderedHitTriplets::iterator hitTripletsEnd,
+                   LayerHitMapCache&& cache) {
+    layerTriplets_.emplace_back(layerPair, thirdLayer, std::distance(hitTripletsBegin, hitTripletsEnd), std::move(cache));
+    std::move(hitTripletsBegin, hitTripletsEnd, std::back_inserter(hitTriplets_)); // probably not much different from std::copy as we're just moving pointers...
+  }
+
+private:
+  const SeedingLayerSetsHits *seedingLayers_;
+
+  std::vector<RegionIndex> regions_;
+  std::vector<LayerTripletHitIndex> layerTriplets_;
+  std::vector<OrderedHitTriplet> hitTriplets_;
+};
+
+#endif

--- a/RecoPixelVertexing/PixelTriplets/interface/IntermediateHitTriplets.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/IntermediateHitTriplets.h
@@ -31,6 +31,9 @@ public:
 
     SeedingLayerSetsHits::LayerIndex layerIndex() const { return thirdLayer_; }
 
+    size_t tripletsBegin() const { return hitsBegin_; }
+    size_t tripletsEnd() const { return hitsEnd_; }
+
   private:
     SeedingLayerSetsHits::LayerIndex thirdLayer_;
     size_t hitsBegin_;
@@ -72,18 +75,27 @@ public:
 
   class LayerTripletHits {
   public:
-    LayerTripletHits(const LayerPairAndLayers *layerPairAndLayers,
+    LayerTripletHits(const IntermediateHitTriplets *hitSets,
+                     const LayerPairAndLayers *layerPairAndLayers,
                      const ThirdLayer *thirdLayer):
+      hitSets_(hitSets),
       layerPairAndLayers_(layerPairAndLayers),
       thirdLayer_(thirdLayer)
     {}
+
+    using TripletRange = std::pair<std::vector<OrderedHitTriplet>::const_iterator,
+                                   std::vector<OrderedHitTriplet>::const_iterator>;
 
     SeedingLayerSetsHits::LayerIndex innerLayerIndex() const { return std::get<0>(layerPairAndLayers_->layerPair()); }
     SeedingLayerSetsHits::LayerIndex middleLayerIndex() const { return std::get<1>(layerPairAndLayers_->layerPair()); }
     SeedingLayerSetsHits::LayerIndex outerLayerIndex() const { return thirdLayer_->layerIndex(); }
 
+    std::vector<OrderedHitTriplet>::const_iterator tripletsBegin() const { return hitSets_->tripletsBegin() + thirdLayer_->tripletsBegin(); }
+    std::vector<OrderedHitTriplet>::const_iterator tripletsEnd() const { return hitSets_->tripletsBegin() + thirdLayer_->tripletsEnd(); }
+
     const LayerHitMapCache& cache() const { return layerPairAndLayers_->cache(); }
   private:
+    const IntermediateHitTriplets *hitSets_;
     const LayerPairAndLayers *layerPairAndLayers_;
     const ThirdLayer *thirdLayer_;
   };
@@ -95,7 +107,7 @@ public:
   public:
     using LayerPairAndLayersConstIterator = std::vector<LayerPairAndLayers>::const_iterator;
     using ThirdLayerConstIterator = std::vector<ThirdLayer>::const_iterator;
-    using HitConstIterator = std::vector<OrderedHitTriplet>::const_iterator;
+    using TripletConstIterator = std::vector<OrderedHitTriplet>::const_iterator;
 
     class const_iterator {
     public:
@@ -103,7 +115,10 @@ public:
       using value_type = LayerTripletHits;
       using difference_type = internal_iterator_type::difference_type;
 
-      const_iterator(const RegionLayerHits *regionLayerHits):
+      struct end_tag {};
+
+      const_iterator(const IntermediateHitTriplets *hitSets, const RegionLayerHits *regionLayerHits):
+        hitSets_(hitSets),
         regionLayerHits_(regionLayerHits),
         iterPair_(regionLayerHits->layerSetsBegin()),
         indThird_(iterPair_->thirdLayersBegin())
@@ -111,15 +126,26 @@ public:
         assert(regionLayerHits->layerSetsBegin() != regionLayerHits->layerSetsEnd());
       }
 
+      const_iterator(const IntermediateHitTriplets *hitSets, const RegionLayerHits *regionLayerHits, end_tag):
+        iterPair_(regionLayerHits->layerSetsEnd()),
+        indThird_(std::numeric_limits<size_t>::max())
+      {}
+
       value_type operator*() const {
-        return value_type(&(*iterPair_), &(*(regionLayerHits_->thirdLayerBegin() + indThird_)));
+        assert(static_cast<unsigned>(indThird_) < std::distance(hitSets_->thirdLayersBegin(), hitSets_->thirdLayersEnd()));
+        return value_type(hitSets_, &(*iterPair_), &(*(hitSets_->thirdLayersBegin() + indThird_)));
       }
 
       const_iterator& operator++() {
         auto nextThird = indThird_+1;
         if(nextThird == iterPair_->thirdLayersEnd()) {
           ++iterPair_;
-          indThird_ = iterPair_->thirdLayersBegin();
+          if(iterPair_ != regionLayerHits_->layerSetsEnd()) {
+            indThird_ = iterPair_->thirdLayersBegin();
+          }
+          else {
+            indThird_ = std::numeric_limits<size_t>::max();
+          }
         }
         else {
           indThird_ = nextThird;
@@ -137,41 +163,43 @@ public:
       bool operator!=(const const_iterator& other) const { return !operator==(other); }
 
     private:
+      const IntermediateHitTriplets *hitSets_;
       const RegionLayerHits *regionLayerHits_;
       internal_iterator_type iterPair_;
       size_t indThird_;
     };
 
     RegionLayerHits(const TrackingRegion* region,
-                    LayerPairAndLayersConstIterator pairBegin, LayerPairAndLayersConstIterator pairEnd,
-                    ThirdLayerConstIterator thirdBegin, ThirdLayerConstIterator thirdEnd):
+                    const IntermediateHitTriplets *hitSets,
+                    LayerPairAndLayersConstIterator pairBegin,
+                    LayerPairAndLayersConstIterator pairEnd):
       region_(region),
-      layerSetsBegin_(pairBegin), layerSetsEnd_(pairEnd),
-      thirdBegin_(thirdBegin), thirdEnd_(thirdEnd)
+      hitSets_(hitSets),
+      layerSetsBegin_(pairBegin), layerSetsEnd_(pairEnd)
     {}
 
     const TrackingRegion& region() const { return *region_; }
     size_t layerPairAndLayersSize() const { return std::distance(layerSetsBegin_, layerSetsEnd_); }
 
-    /*
-    const_iterator begin() const { return layerSetsBegin_; }
+    const_iterator begin() const {
+      if(layerSetsBegin_ != layerSetsEnd_)
+        return const_iterator(hitSets_, this);
+      else
+        return end();
+    }
     const_iterator cbegin() const { return begin(); }
-    const_iterator end() const { return layerSetsEnd_; }
+    const_iterator end() const { return const_iterator(hitSets_, this, const_iterator::end_tag()); }
     const_iterator cend() const { return end(); }
-    */
 
     // used internally
     LayerPairAndLayersConstIterator layerSetsBegin() const { return layerSetsBegin_; }
     LayerPairAndLayersConstIterator layerSetsEnd() const { return layerSetsEnd_; }
-    ThirdLayerConstIterator thirdLayerBegin() const { return thirdBegin_; }
-    ThirdLayerConstIterator thirdLayerEnd() const { return thirdEnd_; }
 
   private:
-    const TrackingRegion *region_;
+    const TrackingRegion *region_ = nullptr;
+    const IntermediateHitTriplets *hitSets_ = nullptr;
     const LayerPairAndLayersConstIterator layerSetsBegin_;
     const LayerPairAndLayersConstIterator layerSetsEnd_;
-    const ThirdLayerConstIterator thirdBegin_;
-    const ThirdLayerConstIterator thirdEnd_;
   };
 
   ////////////////////
@@ -265,6 +293,10 @@ public:
   std::vector<RegionIndex>::const_iterator regionsEnd() const { return regions_.end(); }
   std::vector<LayerPairAndLayers>::const_iterator layerSetsBegin() const { return layerPairAndLayers_.begin(); }
   std::vector<LayerPairAndLayers>::const_iterator layerSetsEnd() const { return layerPairAndLayers_.end(); }
+  std::vector<ThirdLayer>::const_iterator thirdLayersBegin() const { return thirdLayers_.begin(); }
+  std::vector<ThirdLayer>::const_iterator thirdLayersEnd() const { return thirdLayers_.end(); }
+  std::vector<OrderedHitTriplet>::const_iterator tripletsBegin() const { return hitTriplets_.begin(); }
+  std::vector<OrderedHitTriplet>::const_iterator tripletsEnd() const { return hitTriplets_.end(); }
 
 private:
   // to be called if no triplets are added

--- a/RecoPixelVertexing/PixelTriplets/interface/IntermediateHitTriplets.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/IntermediateHitTriplets.h
@@ -24,30 +24,159 @@ public:
   class ThirdLayer {
   public:
     ThirdLayer(const SeedingLayerSetsHits::SeedingLayer& thirdLayer, size_t hitsBegin):
-      thirdLayer_(thirdLayer.index()), hitsBegin_(hitsBegin)
+      thirdLayer_(thirdLayer.index()), hitsBegin_(hitsBegin), hitsEnd_(hitsBegin)
     {}
+
+    void setHitsEnd(size_t end) { hitsEnd_ = end; }
+
+    SeedingLayerSetsHits::LayerIndex layerIndex() const { return thirdLayer_; }
 
   private:
     SeedingLayerSetsHits::LayerIndex thirdLayer_;
     size_t hitsBegin_;
+    size_t hitsEnd_;
   };
 
   ////////////////////
 
   class LayerPairAndLayers {
   public:
-    LayerPairAndLayers(const SeedingLayerSetsHits::SeedingLayerSet& layerPair,
+    LayerPairAndLayers(const LayerPair& layerPair,
                        size_t thirdLayersBegin, LayerHitMapCache&& cache):
-      layerPair_(layerPair[0].index(), layerPair[1].index()),
+      layerPair_(layerPair),
       thirdLayersBegin_(thirdLayersBegin),
+      thirdLayersEnd_(thirdLayersBegin),
       cache_(std::move(cache))
     {}
+
+    void setThirdLayersEnd(size_t end) { thirdLayersEnd_ = end; }
+
+    const LayerPair& layerPair() const { return layerPair_; }
+    size_t thirdLayersBegin() const { return thirdLayersBegin_; }
+    size_t thirdLayersEnd() const { return thirdLayersEnd_; }
+
+    LayerHitMapCache& cache() { return cache_; }
+    const LayerHitMapCache& cache() const { return cache_; }
 
   private:
     LayerPair layerPair_;
     size_t thirdLayersBegin_;
+    size_t thirdLayersEnd_;
+    // The reason for not storing layer triplets + hit triplets
+    // directly is in this cache, and in my desire to try to keep
+    // results unchanged during this refactoring
     LayerHitMapCache cache_;
   };
+
+  ////////////////////
+
+  class LayerTripletHits {
+  public:
+    LayerTripletHits(const LayerPairAndLayers *layerPairAndLayers,
+                     const ThirdLayer *thirdLayer):
+      layerPairAndLayers_(layerPairAndLayers),
+      thirdLayer_(thirdLayer)
+    {}
+
+    SeedingLayerSetsHits::LayerIndex innerLayerIndex() const { return std::get<0>(layerPairAndLayers_->layerPair()); }
+    SeedingLayerSetsHits::LayerIndex middleLayerIndex() const { return std::get<1>(layerPairAndLayers_->layerPair()); }
+    SeedingLayerSetsHits::LayerIndex outerLayerIndex() const { return thirdLayer_->layerIndex(); }
+
+    const LayerHitMapCache& cache() const { return layerPairAndLayers_->cache(); }
+  private:
+    const LayerPairAndLayers *layerPairAndLayers_;
+    const ThirdLayer *thirdLayer_;
+  };
+
+  ////////////////////
+
+  //using RegionLayerHits = ihd::RegionLayerHits<LayerPairAndLayers>;
+  class RegionLayerHits {
+  public:
+    using LayerPairAndLayersConstIterator = std::vector<LayerPairAndLayers>::const_iterator;
+    using ThirdLayerConstIterator = std::vector<ThirdLayer>::const_iterator;
+    using HitConstIterator = std::vector<OrderedHitTriplet>::const_iterator;
+
+    class const_iterator {
+    public:
+      using internal_iterator_type = LayerPairAndLayersConstIterator;
+      using value_type = LayerTripletHits;
+      using difference_type = internal_iterator_type::difference_type;
+
+      const_iterator(const RegionLayerHits *regionLayerHits):
+        regionLayerHits_(regionLayerHits),
+        iterPair_(regionLayerHits->layerSetsBegin()),
+        indThird_(iterPair_->thirdLayersBegin())
+      {
+        assert(regionLayerHits->layerSetsBegin() != regionLayerHits->layerSetsEnd());
+      }
+
+      value_type operator*() const {
+        return value_type(&(*iterPair_), &(*(regionLayerHits_->thirdLayerBegin() + indThird_)));
+      }
+
+      const_iterator& operator++() {
+        auto nextThird = indThird_+1;
+        if(nextThird == iterPair_->thirdLayersEnd()) {
+          ++iterPair_;
+          indThird_ = iterPair_->thirdLayersBegin();
+        }
+        else {
+          indThird_ = nextThird;
+        }
+        return *this;
+      }
+
+      const_iterator operator++(int) {
+        const_iterator clone(*this);
+        operator++();
+        return clone;
+      }
+
+      bool operator==(const const_iterator& other) const { return iterPair_ == other.iterPair_ && indThird_ == other.indThird_; }
+      bool operator!=(const const_iterator& other) const { return !operator==(other); }
+
+    private:
+      const RegionLayerHits *regionLayerHits_;
+      internal_iterator_type iterPair_;
+      size_t indThird_;
+    };
+
+    RegionLayerHits(const TrackingRegion* region,
+                    LayerPairAndLayersConstIterator pairBegin, LayerPairAndLayersConstIterator pairEnd,
+                    ThirdLayerConstIterator thirdBegin, ThirdLayerConstIterator thirdEnd):
+      region_(region),
+      layerSetsBegin_(pairBegin), layerSetsEnd_(pairEnd),
+      thirdBegin_(thirdBegin), thirdEnd_(thirdEnd)
+    {}
+
+    const TrackingRegion& region() const { return *region_; }
+    size_t layerPairAndLayersSize() const { return std::distance(layerSetsBegin_, layerSetsEnd_); }
+
+    /*
+    const_iterator begin() const { return layerSetsBegin_; }
+    const_iterator cbegin() const { return begin(); }
+    const_iterator end() const { return layerSetsEnd_; }
+    const_iterator cend() const { return end(); }
+    */
+
+    // used internally
+    LayerPairAndLayersConstIterator layerSetsBegin() const { return layerSetsBegin_; }
+    LayerPairAndLayersConstIterator layerSetsEnd() const { return layerSetsEnd_; }
+    ThirdLayerConstIterator thirdLayerBegin() const { return thirdBegin_; }
+    ThirdLayerConstIterator thirdLayerEnd() const { return thirdEnd_; }
+
+  private:
+    const TrackingRegion *region_;
+    const LayerPairAndLayersConstIterator layerSetsBegin_;
+    const LayerPairAndLayersConstIterator layerSetsEnd_;
+    const ThirdLayerConstIterator thirdBegin_;
+    const ThirdLayerConstIterator thirdEnd_;
+  };
+
+  ////////////////////
+
+  using const_iterator = ihd::const_iterator<RegionLayerHits, IntermediateHitTriplets>;
 
   ////////////////////
 
@@ -82,8 +211,9 @@ public:
     regions_.emplace_back(region, layerPairAndLayers_.size());
   }
 
-  void beginPair(const SeedingLayerSetsHits::SeedingLayerSet& layerPair, LayerHitMapCache&& cache) {
+  LayerHitMapCache *beginPair(const LayerPair& layerPair, LayerHitMapCache&& cache) {
     layerPairAndLayers_.emplace_back(layerPair, thirdLayers_.size(), std::move(cache));
+    return &(layerPairAndLayers_.back().cache());
   };
 
   void addTriplets(const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers,
@@ -92,6 +222,13 @@ public:
                    const std::vector<size_t>& permutations) {
     assert(triplets.size() == thirdLayerIndex.size());
     assert(triplets.size() == permutations.size());
+
+    if(triplets.empty()) {
+      // In absence of triplets for a layer pair simplest is just
+      // remove the pair
+      popPair();
+      return;
+    }
 
     int prevLayer = -1;
     for(size_t i=0, size=permutations.size(); i<size; ++i) {
@@ -104,13 +241,37 @@ public:
       if(layer != prevLayer) {
         prevLayer = layer;
         thirdLayers_.emplace_back(thirdLayers[layer], hitTriplets_.size());
+        layerPairAndLayers_.back().setThirdLayersEnd(thirdLayers_.size());
       }
 
       hitTriplets_.emplace_back(triplets[realIndex]);
+      thirdLayers_.back().setHitsEnd(hitTriplets_.size());
     }
+
+    regions_.back().setLayerSetsEnd(layerPairAndLayers_.size());
   }
 
+  const SeedingLayerSetsHits& seedingLayerHits() const { return *seedingLayers_; }
+  size_t regionSize() const { return regions_.size(); }
+  size_t tripletsSize() const { return hitTriplets_.size(); }
+
+  const_iterator begin() const { return const_iterator(this, regions_.begin()); }
+  const_iterator cbegin() const { return begin(); }
+  const_iterator end() const { return const_iterator(this, regions_.end()); }
+  const_iterator cend() const { return end(); }
+
+  // used internally
+  std::vector<RegionIndex>::const_iterator regionsBegin() const { return regions_.begin(); }
+  std::vector<RegionIndex>::const_iterator regionsEnd() const { return regions_.end(); }
+  std::vector<LayerPairAndLayers>::const_iterator layerSetsBegin() const { return layerPairAndLayers_.begin(); }
+  std::vector<LayerPairAndLayers>::const_iterator layerSetsEnd() const { return layerPairAndLayers_.end(); }
+
 private:
+  // to be called if no triplets are added
+  void popPair() {
+    layerPairAndLayers_.pop_back();
+  }
+
   const SeedingLayerSetsHits *seedingLayers_;
 
   std::vector<RegionIndex> regions_;

--- a/RecoPixelVertexing/PixelTriplets/interface/IntermediateHitTriplets.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/IntermediateHitTriplets.h
@@ -280,6 +280,7 @@ public:
   }
 
   const SeedingLayerSetsHits& seedingLayerHits() const { return *seedingLayers_; }
+  bool empty() const { return regions_.empty(); }
   size_t regionSize() const { return regions_.size(); }
   size_t tripletsSize() const { return hitTriplets_.size(); }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletEDProducer.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletEDProducer.cc
@@ -59,6 +59,10 @@ void PixelQuadrupletEDProducer::produce(edm::Event& iEvent, const edm::EventSetu
   }
 
   auto seedingHitSets = std::make_unique<RegionsSeedingHitSets>();
+  if(regionTriplets.empty()) {
+    iEvent.put(std::move(seedingHitSets));
+    return;
+  }
   seedingHitSets->reserve(regionTriplets.regionSize(), localRA_.upper());
 
   // match-making of triplet and quadruplet layers

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletEDProducer.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletEDProducer.cc
@@ -1,0 +1,123 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Utilities/interface/RunningAverage.h"
+
+#include "RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/OrderedHitSeeds.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/IntermediateHitTriplets.h"
+
+#include "PixelQuadrupletGenerator.h"
+#include "LayerQuadruplets.h"
+
+class PixelQuadrupletEDProducer: public edm::stream::EDProducer<> {
+public:
+  PixelQuadrupletEDProducer(const edm::ParameterSet& iConfig);
+  ~PixelQuadrupletEDProducer() = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  virtual void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+
+private:
+  edm::EDGetTokenT<IntermediateHitTriplets> tripletToken_;
+
+  edm::RunningAverage localRA_;
+
+  PixelQuadrupletGenerator generator_;
+};
+
+PixelQuadrupletEDProducer::PixelQuadrupletEDProducer(const edm::ParameterSet& iConfig):
+  tripletToken_(consumes<IntermediateHitTriplets>(iConfig.getParameter<edm::InputTag>("triplets"))),
+  generator_(iConfig, consumesCollector())
+{
+  produces<std::vector<SeedingHitSet> >();
+}
+
+void PixelQuadrupletEDProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add<edm::InputTag>("triplets", edm::InputTag("hitTripletEDProducer"));
+  PixelQuadrupletGenerator::fillDescriptions(desc);
+
+  descriptions.add("pixelQuadrupletEDProducer", desc);
+}
+
+void PixelQuadrupletEDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<IntermediateHitTriplets> htriplets;
+  iEvent.getByToken(tripletToken_, htriplets);
+  const auto& regionTriplets = *htriplets;
+
+  const SeedingLayerSetsHits& seedingLayerHits = regionTriplets.seedingLayerHits();
+  if(seedingLayerHits.numberOfLayersInSet() < 4) {
+    throw cms::Exception("Configuration") << "PixelQuadrupletEDProducer expects SeedingLayerSetsHits::numberOfLayersInSet() to be >= 4, got " << seedingLayerHits.numberOfLayersInSet();
+  }
+
+  auto seedingHitSets = std::make_unique<std::vector<SeedingHitSet> >();
+  seedingHitSets->reserve(localRA_.upper());
+
+  // match-making of triplet and quadruplet layers
+  std::vector<LayerQuadruplets::LayerSetAndLayers> quadlayers = LayerQuadruplets::layers(seedingLayerHits);
+
+  LogDebug("HitQuadrupletEDProducer") << "Creating quadruplets for " << regionTriplets.regionSize() << " regions, and " << quadlayers.size() << " triplet+4th layers from " << regionTriplets.tripletsSize() << " triplets";
+
+  OrderedHitSeeds quadruplets;
+  quadruplets.reserve(localRA_.upper());
+
+  for(const auto& regionLayerPairAndLayers: regionTriplets) {
+    const TrackingRegion& region = regionLayerPairAndLayers.region();
+
+    LogTrace("HitQuadrupletEDProducer") << " starting region, number of layerPair+3rd layers " << regionLayerPairAndLayers.layerPairAndLayersSize();
+
+    for(const auto& layerTriplet: regionLayerPairAndLayers) {
+      LogTrace("HitQuadrupletEDProducer") << "  starting layer triplet " << layerTriplet.innerLayerIndex() << "," << layerTriplet.middleLayerIndex() << "," << layerTriplet.outerLayerIndex();
+      auto found = std::find_if(quadlayers.begin(), quadlayers.end(), [&](const LayerQuadruplets::LayerSetAndLayers& a) {
+          return a.first[0].index() == layerTriplet.innerLayerIndex() &&
+                 a.first[1].index() == layerTriplet.middleLayerIndex() &&
+                 a.first[2].index() == layerTriplet.outerLayerIndex();
+        });
+      if(found == quadlayers.end()) {
+        auto exp = cms::Exception("LogicError") << "Did not find the layer triplet from vector<triplet+fourth layers>. This is a sign of some internal inconsistency\n";
+        exp << "I was looking for layer triplet " << layerTriplet.innerLayerIndex() << "," << layerTriplet.middleLayerIndex() << "," << layerTriplet.outerLayerIndex()
+            << ". Quadruplets have the following triplets:\n";
+        for(const auto& a: quadlayers) {
+          exp << " " << a.first[0].index() << "," << a.first[1].index() << "," << a.first[2].index() << ": 4th layers";
+          for(const auto& b: a.second) {
+            exp << " " << b.index();
+          }
+          exp << "\n";
+        }
+        throw exp;
+      }
+      const auto& fourthLayers = found->second;
+
+      LayerHitMapCache hitCache;
+      hitCache.extend(layerTriplet.cache());
+
+      generator_.hitQuadruplets(region, quadruplets, iEvent, iSetup, layerTriplet.tripletsBegin(), layerTriplet.tripletsEnd(), fourthLayers, hitCache);
+
+#ifdef EDM_ML_DEBUG
+      LogTrace("HitQuadrupletEDProducer") << "  created " << quadruplets.size() << " quadruplets for layer triplet " << layerTriplet.innerLayerIndex() << "," << layerTriplet.middleLayerIndex() << "," << layerTriplet.outerLayerIndex() << " and 4th layers";
+      for(const auto& l: fourthLayers) {
+        LogTrace("HitQuadrupletEDProducer") << "   " << l.index();
+      }
+#endif
+
+      for(const auto& quad: quadruplets) {
+        seedingHitSets->emplace_back(quad[0], quad[1], quad[2], quad[3]);
+      }
+      quadruplets.clear();
+    }
+  }
+  localRA_.update(seedingHitSets->size());
+
+  iEvent.put(std::move(seedingHitSets));
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(PixelQuadrupletEDProducer);

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletEDProducer.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletEDProducer.cc
@@ -8,7 +8,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Utilities/interface/RunningAverage.h"
 
-#include "RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h"
+#include "RecoTracker/TkHitPairs/interface/RegionsSeedingHitSets.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/OrderedHitSeeds.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/IntermediateHitTriplets.h"
 
@@ -36,7 +36,7 @@ PixelQuadrupletEDProducer::PixelQuadrupletEDProducer(const edm::ParameterSet& iC
   tripletToken_(consumes<IntermediateHitTriplets>(iConfig.getParameter<edm::InputTag>("triplets"))),
   generator_(iConfig, consumesCollector())
 {
-  produces<std::vector<SeedingHitSet> >();
+  produces<RegionsSeedingHitSets>();
 }
 
 void PixelQuadrupletEDProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -58,8 +58,8 @@ void PixelQuadrupletEDProducer::produce(edm::Event& iEvent, const edm::EventSetu
     throw cms::Exception("Configuration") << "PixelQuadrupletEDProducer expects SeedingLayerSetsHits::numberOfLayersInSet() to be >= 4, got " << seedingLayerHits.numberOfLayersInSet();
   }
 
-  auto seedingHitSets = std::make_unique<std::vector<SeedingHitSet> >();
-  seedingHitSets->reserve(localRA_.upper());
+  auto seedingHitSets = std::make_unique<RegionsSeedingHitSets>();
+  seedingHitSets->reserve(regionTriplets.regionSize(), localRA_.upper());
 
   // match-making of triplet and quadruplet layers
   std::vector<LayerQuadruplets::LayerSetAndLayers> quadlayers = LayerQuadruplets::layers(seedingLayerHits);
@@ -71,6 +71,7 @@ void PixelQuadrupletEDProducer::produce(edm::Event& iEvent, const edm::EventSetu
 
   for(const auto& regionLayerPairAndLayers: regionTriplets) {
     const TrackingRegion& region = regionLayerPairAndLayers.region();
+    auto seedingHitSetsFiller = seedingHitSets->beginRegion(&region);
 
     LogTrace("HitQuadrupletEDProducer") << " starting region, number of layerPair+3rd layers " << regionLayerPairAndLayers.layerPairAndLayersSize();
 
@@ -109,7 +110,7 @@ void PixelQuadrupletEDProducer::produce(edm::Event& iEvent, const edm::EventSetu
 #endif
 
       for(const auto& quad: quadruplets) {
-        seedingHitSets->emplace_back(quad[0], quad[1], quad[2], quad[3]);
+        seedingHitSetsFiller.emplace_back(quad[0], quad[1], quad[2], quad[3]);
       }
       quadruplets.clear();
     }

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletGenerator.cc
@@ -80,7 +80,7 @@ void PixelQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region, Orde
 
   // Build KDtrees
   for(size_t il=0; il!=size; ++il) {
-    fourthHitMap[il] = &(*theLayerCache)(fourthLayers[il], region, ev, es);
+    fourthHitMap[il] = &(*theLayerCache)(fourthLayers[il], region, es);
     auto const& hits = *fourthHitMap[il];
 
     ThirdHitRZPrediction<PixelRecoLineRZ> & pred = preds[il];

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletGenerator.cc
@@ -2,6 +2,7 @@
 #include "ThirdHitRZPrediction.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/ThirdHitPredictionFromCircle.h"
 #include "RecoTracker/TkMSParametrization/interface/PixelRecoLineRZ.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 #include "RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerAlgo.h"
 #include "RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerTools.h"
@@ -50,19 +51,60 @@ PixelQuadrupletGenerator::PixelQuadrupletGenerator(const edm::ParameterSet& cfg,
 
 PixelQuadrupletGenerator::~PixelQuadrupletGenerator() {}
 
+void PixelQuadrupletGenerator::fillDescriptions(edm::ParameterSetDescription& desc) {
+  desc.add<double>("extraHitRZtolerance", 0.1);
+  desc.add<double>("extraHitRPhitolerance", 0.1);
+
+  edm::ParameterSetDescription descExtraPhi;
+  descExtraPhi.add<double>("pt1", 0.1);
+  descExtraPhi.add<double>("pt2", 0.1);
+  descExtraPhi.add<double>("value1", 999);
+  descExtraPhi.add<double>("value2", 0.15);
+  descExtraPhi.add<bool>("enabled", false);
+  desc.add<edm::ParameterSetDescription>("extraPhiTolerance", descExtraPhi);
+
+  edm::ParameterSetDescription descMaxChi2;
+  descMaxChi2.add<double>("pt1", 0.2);
+  descMaxChi2.add<double>("pt2", 1.5);
+  descMaxChi2.add<double>("value1", 500);
+  descMaxChi2.add<double>("value2", 50);
+  descMaxChi2.add<bool>("enabled", true);
+  desc.add<edm::ParameterSetDescription>("maxChi2", descMaxChi2);
+
+  desc.add<bool>("fitFastCircle", false);
+  desc.add<bool>("fitFastCircleChi2Cut", false);
+  desc.add<bool>("useBendingCorrection", false);
+
+  edm::ParameterSetDescription descComparitor;
+  descComparitor.add<std::string>("ComponentName", "none");
+  descComparitor.setAllowAnything(); // until we have moved SeedComparitor too to EDProducers
+  desc.add<edm::ParameterSetDescription>("SeedComparitorPSet", descComparitor);
+}
+
 
 void PixelQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region, OrderedHitSeeds& result,
                                               const edm::Event& ev, const edm::EventSetup& es,
                                               const SeedingLayerSetsHits::SeedingLayerSet& tripletLayers,
                                               const std::vector<SeedingLayerSetsHits::SeedingLayer>& fourthLayers)
 {
-  if (theComparitor) theComparitor->init(ev, es);
-
   OrderedHitTriplets triplets;
   theTripletGenerator->hitTriplets(region, triplets, ev, es,
                                    tripletLayers, // pair generator picks the correct two layers from these
                                    std::vector<SeedingLayerSetsHits::SeedingLayer>{tripletLayers[2]});
   if(triplets.empty()) return;
+
+  assert(theLayerCache);
+  hitQuadruplets(region, result, ev, es, triplets.begin(), triplets.end(), fourthLayers, *theLayerCache);
+}
+
+void PixelQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region, OrderedHitSeeds& result,
+                                              const edm::Event& ev, const edm::EventSetup& es,
+                                              OrderedHitTriplets::const_iterator tripletsBegin,
+                                              OrderedHitTriplets::const_iterator tripletsEnd,
+                                              const std::vector<SeedingLayerSetsHits::SeedingLayer>& fourthLayers,
+                                              LayerCacheType& layerCache)
+{
+  if (theComparitor) theComparitor->init(ev, es);
 
   const size_t size = fourthLayers.size();
 
@@ -80,7 +122,7 @@ void PixelQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region, Orde
 
   // Build KDtrees
   for(size_t il=0; il!=size; ++il) {
-    fourthHitMap[il] = &(*theLayerCache)(fourthLayers[il], region, es);
+    fourthHitMap[il] = &(layerCache)(fourthLayers[il], region, es);
     auto const& hits = *fourthHitMap[il];
 
     ThirdHitRZPrediction<PixelRecoLineRZ> & pred = preds[il];
@@ -117,7 +159,8 @@ void PixelQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region, Orde
   std::vector<float> bc_r(4), bc_z(4), bc_errZ(4);
 
   // Loop over triplets
-  for(const auto& triplet: triplets) {
+  for(auto iTriplet = tripletsBegin; iTriplet != tripletsEnd; ++iTriplet) {
+    const auto& triplet = *iTriplet;
     GlobalPoint gp0 = triplet.inner()->globalPosition();
     GlobalPoint gp1 = triplet.middle()->globalPosition();
     GlobalPoint gp2 = triplet.outer()->globalPosition();

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelQuadrupletGenerator.h
@@ -21,14 +21,24 @@ class PixelQuadrupletGenerator : public HitQuadrupletGeneratorFromTripletAndLaye
 typedef CombinedHitQuadrupletGenerator::LayerCacheType       LayerCacheType;
 
 public:
+  PixelQuadrupletGenerator( const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC): PixelQuadrupletGenerator(cfg, iC) {}
   PixelQuadrupletGenerator( const edm::ParameterSet& cfg, edm::ConsumesCollector& iC);
 
   virtual ~PixelQuadrupletGenerator();
+
+  static void fillDescriptions(edm::ParameterSetDescription& desc);
 
   virtual void hitQuadruplets( const TrackingRegion& region, OrderedHitSeeds& result,
                                const edm::Event & ev, const edm::EventSetup& es,
                                const SeedingLayerSetsHits::SeedingLayerSet& tripletLayers,
                                const std::vector<SeedingLayerSetsHits::SeedingLayer>& fourthLayers) override;
+
+  void hitQuadruplets( const TrackingRegion& region, OrderedHitSeeds& result,
+                       const edm::Event& ev, const edm::EventSetup& es,
+                       OrderedHitTriplets::const_iterator tripletsBegin,
+                       OrderedHitTriplets::const_iterator tripletsEnd,
+                       const std::vector<SeedingLayerSetsHits::SeedingLayer>& fourthLayers,
+                       LayerCacheType& layerCache);
 
 private:
   std::unique_ptr<SeedComparitor> theComparitor;
@@ -38,6 +48,8 @@ private:
     QuantityDependsPtEval(float v1, float v2, float c1, float c2):
       value1_(v1), value2_(v2), curvature1_(c1), curvature2_(c2)
     {}
+
+    static void fillDescriptions(edm::ParameterSetDescription& desc);
 
     float value(float curvature) const {
       if(value1_ == value2_) // not enabled

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
@@ -60,18 +60,26 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
 					   const SeedingLayerSetsHits::SeedingLayerSet& pairLayers,
 					   const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers)
 {
-    if (theComparitor) theComparitor->init(ev, es);
-    
     auto const & doublets = thePairGenerator->doublets(region,ev,es, pairLayers);
-    
     if (doublets.empty()) return;
+
+    assert(theLayerCache);
+    hitTriplets(region, result, ev, es, doublets, thirdLayers, *theLayerCache);
+}
+
+void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region, OrderedHitTriplets& result,
+                                           const edm::Event& ev, const edm::EventSetup& es,
+                                           const HitDoublets& doublets,
+                                           const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers,
+                                           LayerCacheType& layerCache) {
+    if (theComparitor) theComparitor->init(ev, es);
 
     int size = thirdLayers.size();
     const RecHitsSortedInPhi * thirdHitMap[size];
     vector<const DetLayer *> thirdLayerDetLayer(size,0);
     for (int il=0; il<size; ++il) 
     {
-	thirdHitMap[il] = &(*theLayerCache)(thirdLayers[il], region, es);
+	thirdHitMap[il] = &layerCache(thirdLayers[il], region, es);
 	thirdLayerDetLayer[il] = thirdLayers[il].detLayer();
     }
     hitTriplets(region,result,es,doublets,thirdHitMap,thirdLayerDetLayer,size);

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
@@ -1,5 +1,6 @@
 #include "RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.h"
 #include "RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 #include "ThirdHitPredictionFromInvParabola.h"
 #include "ThirdHitRZPrediction.h"
@@ -53,6 +54,21 @@ PixelTripletHLTGenerator:: PixelTripletHLTGenerator(const edm::ParameterSet& cfg
 
 PixelTripletHLTGenerator::~PixelTripletHLTGenerator() {}
 
+void PixelTripletHLTGenerator::fillDescriptions(edm::ParameterSetDescription& desc) {
+  HitTripletGeneratorFromPairAndLayers::fillDescriptions(desc);
+  desc.add<double>("extraHitRPhitolerance", 0.032);
+  desc.add<double>("extraHitRZtolerance", 0.037);
+  desc.add<bool>("useMultScattering", true);
+  desc.add<bool>("useBending", true);
+  desc.add<bool>("useFixedPreFiltering", false);
+  desc.add<double>("phiPreFiltering", 0.3);
+
+  edm::ParameterSetDescription descComparitor;
+  descComparitor.add<std::string>("ComponentName", "none");
+  descComparitor.setAllowAnything(); // until we have moved SeedComparitor too to EDProducers
+  desc.add<edm::ParameterSetDescription>("SeedComparitorPSet", descComparitor);
+}
+
 void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region, 
 					   OrderedHitTriplets & result,
 					   const edm::Event & ev,
@@ -64,13 +80,14 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
     if (doublets.empty()) return;
 
     assert(theLayerCache);
-    hitTriplets(region, result, ev, es, doublets, thirdLayers, *theLayerCache);
+    hitTriplets(region, result, ev, es, doublets, thirdLayers, nullptr, *theLayerCache);
 }
 
 void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region, OrderedHitTriplets& result,
                                            const edm::Event& ev, const edm::EventSetup& es,
                                            const HitDoublets& doublets,
                                            const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers,
+                                           std::vector<unsigned int> *thirdLayerHitBeginIndices,
                                            LayerCacheType& layerCache) {
     if (theComparitor) theComparitor->init(ev, es);
 
@@ -82,7 +99,7 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region, Ordered
 	thirdHitMap[il] = &layerCache(thirdLayers[il], region, es);
 	thirdLayerDetLayer[il] = thirdLayers[il].detLayer();
     }
-    hitTriplets(region,result,es,doublets,thirdHitMap,thirdLayerDetLayer,size);
+    hitTriplets(region, result, es, doublets, thirdHitMap, thirdLayerDetLayer, size, thirdLayerHitBeginIndices);
 }
 
 void PixelTripletHLTGenerator::hitTriplets(
@@ -94,14 +111,24 @@ void PixelTripletHLTGenerator::hitTriplets(
     const std::vector<const DetLayer *> & thirdLayerDetLayer,
     const int nThirdLayers)
 {
-    auto outSeq =  doublets.detLayer(HitDoublets::outer)->seqNum();
+  hitTriplets(region, result, es, doublets, thirdHitMap, thirdLayerDetLayer, nThirdLayers, nullptr);
+}
 
-    float regOffset = region.origin().perp(); //try to take account of non-centrality (?)
-    
-    declareDynArray(ThirdHitRZPrediction<PixelRecoLineRZ>, nThirdLayers, preds);
-    declareDynArray(ThirdHitCorrection, nThirdLayers, corrections);
-  
-    typedef RecHitsSortedInPhi::Hit Hit;
+void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region, OrderedHitTriplets & result,
+                                           const edm::EventSetup & es,
+                                           const HitDoublets & doublets,
+                                           const RecHitsSortedInPhi ** thirdHitMap,
+                                           const std::vector<const DetLayer *> & thirdLayerDetLayer,
+                                           const int nThirdLayers,
+                                           std::vector<unsigned int> *thirdLayerHitBeginIndices) {
+  auto outSeq =  doublets.detLayer(HitDoublets::outer)->seqNum();
+
+  float regOffset = region.origin().perp(); //try to take account of non-centrality (?)
+
+  declareDynArray(ThirdHitRZPrediction<PixelRecoLineRZ>, nThirdLayers, preds);
+  declareDynArray(ThirdHitCorrection, nThirdLayers, corrections);
+
+  typedef RecHitsSortedInPhi::Hit Hit;
 
   using NodeInfo = KDTreeNodeInfo<unsigned int>;
   std::vector<NodeInfo > layerTree; // re-used throughout
@@ -180,6 +207,9 @@ void PixelTripletHLTGenerator::hitTriplets(
     for (int il=0; il!=nThirdLayers; ++il) {
       const DetLayer * layer = thirdLayerDetLayer[il];
       auto barrelLayer = layer->isBarrel();
+
+      // to bookkeep the triplets and 3rd layers in triplet EDProducer
+      if(thirdLayerHitBeginIndices) thirdLayerHitBeginIndices->push_back(result.size());
 
       if ( (!barrelLayer) & (toPos != std::signbit(layer->position().z())) ) continue;
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
@@ -71,7 +71,7 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
     vector<const DetLayer *> thirdLayerDetLayer(size,0);
     for (int il=0; il<size; ++il) 
     {
-	thirdHitMap[il] = &(*theLayerCache)(thirdLayers[il], region, ev, es);
+	thirdHitMap[il] = &(*theLayerCache)(thirdLayers[il], region, es);
 	thirdLayerDetLayer[il] = thirdLayers[il].detLayer();
     }
     hitTriplets(region,result,es,doublets,thirdHitMap,thirdLayerDetLayer,size);

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
@@ -87,7 +87,7 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region, Ordered
                                            const edm::Event& ev, const edm::EventSetup& es,
                                            const HitDoublets& doublets,
                                            const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers,
-                                           std::vector<unsigned int> *thirdLayerHitBeginIndices,
+                                           std::vector<int> *thirdLayerHitBeginIndices,
                                            LayerCacheType& layerCache) {
     if (theComparitor) theComparitor->init(ev, es);
 
@@ -120,7 +120,7 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region, Ordered
                                            const RecHitsSortedInPhi ** thirdHitMap,
                                            const std::vector<const DetLayer *> & thirdLayerDetLayer,
                                            const int nThirdLayers,
-                                           std::vector<unsigned int> *thirdLayerHitBeginIndices) {
+                                           std::vector<int> *thirdLayerHitBeginIndices) {
   auto outSeq =  doublets.detLayer(HitDoublets::outer)->seqNum();
 
   float regOffset = region.origin().perp(); //try to take account of non-centrality (?)
@@ -207,9 +207,6 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region, Ordered
     for (int il=0; il!=nThirdLayers; ++il) {
       const DetLayer * layer = thirdLayerDetLayer[il];
       auto barrelLayer = layer->isBarrel();
-
-      // to bookkeep the triplets and 3rd layers in triplet EDProducer
-      if(thirdLayerHitBeginIndices) thirdLayerHitBeginIndices->push_back(result.size());
 
       if ( (!barrelLayer) & (toPos != std::signbit(layer->position().z())) ) continue;
 
@@ -349,6 +346,8 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region, Ordered
 	    OrderedHitTriplet hittriplet( doublets.hit(ip,HitDoublets::inner), doublets.hit(ip,HitDoublets::outer), hits.theHits[KDdata].hit());
 	    if (!theComparitor  || theComparitor->compatible(hittriplet,region) ) {
 	      result.push_back( hittriplet );
+              // to bookkeep the triplets and 3rd layers in triplet EDProducer
+              if(thirdLayerHitBeginIndices) thirdLayerHitBeginIndices->push_back(il);
 	    } else {
 	      LogDebug("RejectedTriplet") << "rejected triplet from comparitor ";
 	    }

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.h
@@ -31,6 +31,12 @@ public:
                             const SeedingLayerSetsHits::SeedingLayerSet& pairLayers,
                             const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers) override;
 
+  void hitTriplets(const TrackingRegion& region, OrderedHitTriplets& trs,
+                   const edm::Event& ev, const edm::EventSetup& es,
+                   const HitDoublets& doublets,
+                   const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers,
+                   LayerCacheType& layerCache);
+
     void hitTriplets(
 	const TrackingRegion& region, 
 	OrderedHitTriplets & result,

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.h
@@ -22,9 +22,13 @@ class PixelTripletHLTGenerator : public HitTripletGeneratorFromPairAndLayers {
 typedef CombinedHitTripletGenerator::LayerCacheType       LayerCacheType;
 
 public:
+  PixelTripletHLTGenerator( const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC): PixelTripletHLTGenerator(cfg, iC) {}
   PixelTripletHLTGenerator( const edm::ParameterSet& cfg, edm::ConsumesCollector& iC);
 
   virtual ~PixelTripletHLTGenerator();
+
+  static void fillDescriptions(edm::ParameterSetDescription& desc);
+  static const char *fillDescriptionsLabel() { return "pixelTripletHLTEDProducer"; }
 
   virtual void hitTriplets( const TrackingRegion& region, OrderedHitTriplets & trs,
                             const edm::Event & ev, const edm::EventSetup& es,
@@ -35,6 +39,7 @@ public:
                    const edm::Event& ev, const edm::EventSetup& es,
                    const HitDoublets& doublets,
                    const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers,
+                   std::vector<unsigned int> *thirdLayerHitBeginIndices,
                    LayerCacheType& layerCache);
 
     void hitTriplets(
@@ -45,6 +50,14 @@ public:
 	const RecHitsSortedInPhi ** thirdHitMap,
 	const std::vector<const DetLayer *> & thirdLayerDetLayer,
 	const int nThirdLayers)override;
+
+  void hitTriplets(const TrackingRegion& region, OrderedHitTriplets & result,
+                   const edm::EventSetup & es,
+                   const HitDoublets & doublets,
+                   const RecHitsSortedInPhi ** thirdHitMap,
+                   const std::vector<const DetLayer *> & thirdLayerDetLayer,
+                   const int nThirdLayers,
+                   std::vector<unsigned int> *thirdLayerHitBeginIndices);
 
 private:
   const bool useFixedPreFiltering;

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.h
@@ -39,7 +39,7 @@ public:
                    const edm::Event& ev, const edm::EventSetup& es,
                    const HitDoublets& doublets,
                    const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers,
-                   std::vector<unsigned int> *thirdLayerHitBeginIndices,
+                   std::vector<int> *tripletLastLayerIndex,
                    LayerCacheType& layerCache);
 
     void hitTriplets(
@@ -57,7 +57,7 @@ public:
                    const RecHitsSortedInPhi ** thirdHitMap,
                    const std::vector<const DetLayer *> & thirdLayerDetLayer,
                    const int nThirdLayers,
-                   std::vector<unsigned int> *thirdLayerHitBeginIndices);
+                   std::vector<int> *thirdLayerHitBeginIndices);
 
 private:
   const bool useFixedPreFiltering;

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
@@ -86,7 +86,7 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
   vector<const DetLayer *> thirdLayerDetLayer(size,0);
   for (int il=0; il<size; ++il) 
     {
-      thirdHitMap[il] = &(*theLayerCache)(thirdLayers[il], region, ev, es);
+      thirdHitMap[il] = &(*theLayerCache)(thirdLayers[il], region, es);
       thirdLayerDetLayer[il] = thirdLayers[il].detLayer();
     }
   hitTriplets(region,result,es,doublets,thirdHitMap,thirdLayerDetLayer,size);

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletNoTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletNoTipGenerator.cc
@@ -63,7 +63,7 @@ void PixelTripletNoTipGenerator::hitTriplets(
 
   const RecHitsSortedInPhi **thirdHitMap = new const RecHitsSortedInPhi*[size];
   for (int il=0; il <=size-1; il++) {
-     thirdHitMap[il] = &(*theLayerCache)(thirdLayers[il], region, ev, es);
+     thirdHitMap[il] = &(*theLayerCache)(thirdLayers[il], region, es);
   }
 
   const DetLayer * firstLayer = thePairGenerator->innerLayer(pairLayers).detLayer();

--- a/RecoPixelVertexing/PixelTriplets/plugins/SealModule.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/SealModule.cc
@@ -28,3 +28,7 @@ DEFINE_EDM_PLUGIN(HitQuadrupletGeneratorFromTripletAndLayersFactory, PixelQuadru
 
 #include "CAHitQuadrupletGenerator.h"
 DEFINE_EDM_PLUGIN(OrderedHitsGeneratorFactory, CAHitQuadrupletGenerator, "CAHitQuadrupletGenerator");
+
+#include "RecoPixelVertexing/PixelTriplets/interface/HitTripletEDProducerT.h"
+using PixelTripletHLTEDProducer = HitTripletEDProducerT<PixelTripletHLTGenerator>;
+DEFINE_FWK_MODULE(PixelTripletHLTEDProducer);

--- a/RecoPixelVertexing/PixelTriplets/src/HitTripletGeneratorFromPairAndLayers.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/HitTripletGeneratorFromPairAndLayers.cc
@@ -1,6 +1,7 @@
 #include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGeneratorFromPairAndLayers.h"
 #include "RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 HitTripletGeneratorFromPairAndLayers::HitTripletGeneratorFromPairAndLayers(unsigned int maxElement):
   theLayerCache(nullptr),
@@ -12,6 +13,10 @@ HitTripletGeneratorFromPairAndLayers::HitTripletGeneratorFromPairAndLayers(const
 {}
 
 HitTripletGeneratorFromPairAndLayers::~HitTripletGeneratorFromPairAndLayers() {}
+
+void HitTripletGeneratorFromPairAndLayers::fillDescriptions(edm::ParameterSetDescription& desc) {
+  desc.add<unsigned int>("maxElement", 100000);
+}
 
 void HitTripletGeneratorFromPairAndLayers::init(std::unique_ptr<HitPairGeneratorFromLayerPair>&& pairGenerator, LayerCacheType *layerCache) {
   thePairGenerator = std::move(pairGenerator);

--- a/RecoPixelVertexing/PixelTriplets/src/IntermediateHitTriplets.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/IntermediateHitTriplets.cc
@@ -1,0 +1,7 @@
+#include "RecoPixelVertexing/PixelTriplets/interface/IntermediateHitTriplets.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+IntermediateHitTriplets::IntermediateHitTriplets(const IntermediateHitTriplets& rh) {
+  throw cms::Exception("Not Implemented") << "The copy constructor of IntermediateHitTriplets should never be called. The function exists only to make ROOT dictionary generation happy.";
+}
+

--- a/RecoPixelVertexing/PixelTriplets/src/LayerTriplets.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/LayerTriplets.cc
@@ -3,7 +3,7 @@
 namespace LayerTriplets {
 std::vector<LayerSetAndLayers> layers(const SeedingLayerSetsHits& sets) {
   std::vector<LayerSetAndLayers> result;
-  if(sets.numberOfLayersInSet() != 3)
+  if(sets.numberOfLayersInSet() < 3)
     return result;
 
   for(LayerSet set: sets) {
@@ -13,7 +13,10 @@ std::vector<LayerSetAndLayers> layers(const SeedingLayerSetsHits& sets) {
       const LayerSet & resSet = ir->first;
       if (resSet[0].index() == set[0].index() && resSet[1].index() == set[1].index()) {
         std::vector<Layer>& thirds = ir->second;
-        thirds.push_back( set[2] );
+        // 3rd layer can already be there if we are dealing with quadruplet layer sets
+        auto found = std::find_if(thirds.begin(), thirds.end(), [&](const Layer& l) { return l.index() == set[2].index(); });
+        if(found == thirds.end())
+          thirds.push_back( set[2] );
         added = true;
         break;
       }

--- a/RecoPixelVertexing/PixelTriplets/src/classes.h
+++ b/RecoPixelVertexing/PixelTriplets/src/classes.h
@@ -1,0 +1,11 @@
+#include "RecoPixelVertexing/PixelTriplets/interface/IntermediateHitTriplets.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+
+#include <vector>
+
+namespace RecoPixelVertexing_PixelTriplets {
+  struct dictionary {
+    IntermediateHitTriplets iht;
+    edm::Wrapper<IntermediateHitTriplets> wiht;
+  };
+}

--- a/RecoPixelVertexing/PixelTriplets/src/classes_def.xml
+++ b/RecoPixelVertexing/PixelTriplets/src/classes_def.xml
@@ -1,0 +1,4 @@
+<lcgdict>
+  <class name="IntermediateHitTriplets" persistent="false"/>
+  <class name="edm::Wrapper<IntermediateHitTriplets>" persistent="false"/>
+</lcgdict>

--- a/RecoTracker/ConversionSeedGenerators/plugins/HitPairGeneratorFromLayerPairForPhotonConversion.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/HitPairGeneratorFromLayerPairForPhotonConversion.cc
@@ -72,10 +72,10 @@ void HitPairGeneratorFromLayerPairForPhotonConversion::hitPairs(const Conversion
   if(!checkBoundaries(*outerLayerObj.detLayer(),convRegion,50.,60.)) return; //FIXME, the maxSearchR(Z) are not optimized
 
   /*get hit sorted in phi for each layer: NB: doesn't apply any region cut*/
-  const RecHitsSortedInPhi & innerHitsMap = theLayerCache(innerLayerObj, region, event, es);
+  const RecHitsSortedInPhi & innerHitsMap = theLayerCache(innerLayerObj, region, es);
   if (innerHitsMap.empty()) return;
  
-  const RecHitsSortedInPhi& outerHitsMap = theLayerCache(outerLayerObj, region, event, es);
+  const RecHitsSortedInPhi& outerHitsMap = theLayerCache(outerLayerObj, region, es);
   if (outerHitsMap.empty()) return;
   /*----------------*/
 

--- a/RecoTracker/ConversionSeedGenerators/plugins/HitQuadrupletGeneratorFromLayerPairForPhotonConversion.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/HitQuadrupletGeneratorFromLayerPairForPhotonConversion.cc
@@ -63,10 +63,10 @@ void HitQuadrupletGeneratorFromLayerPairForPhotonConversion::hitPairs(const Trac
 #endif
 
   /*get hit sorted in phi for each layer: NB: doesn't apply any region cut*/
-  const RecHitsSortedInPhi & innerHitsMap = theLayerCache(innerLayerObj, region, event, es);
+  const RecHitsSortedInPhi & innerHitsMap = theLayerCache(innerLayerObj, region, es);
   if (innerHitsMap.empty()) return;
  
-  const RecHitsSortedInPhi& outerHitsMap = theLayerCache(outerLayerObj, region, event, es);
+  const RecHitsSortedInPhi& outerHitsMap = theLayerCache(outerLayerObj, region, es);
   if (outerHitsMap.empty()) return;
   /*----------------*/
 

--- a/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
@@ -17,52 +17,69 @@ eras.trackingPhase1.toModify(initialStepSeedLayersPreSplitting,
     layerList = RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff.PixelSeedMergerQuadruplets.layerList.value()
 )
 
-# seeding
-from RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff import *
-from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import RegionPsetFomBeamSpotBlock
-from RecoPixelVertexing.PixelTriplets.PixelQuadrupletGenerator_cfi import PixelQuadrupletGenerator as _PixelQuadrupletGenerator
-initialStepSeedsPreSplitting = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone(
-    RegionFactoryPSet = RegionPsetFomBeamSpotBlock.clone(
-    ComponentName = cms.string('GlobalRegionProducerFromBeamSpot'),
-    RegionPSet = RegionPsetFomBeamSpotBlock.RegionPSet.clone(
-    ptMin = 0.6,
-    originRadius = 0.02,
-    nSigmaZ = 4.0
-    )
-    )
-    )
-initialStepSeedsPreSplitting.OrderedHitsFactoryPSet.SeedingLayers = 'initialStepSeedLayersPreSplitting'
-from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
-import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
-initialStepSeedsPreSplitting.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor.clone()
-initialStepSeedsPreSplitting.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet.clusterShapeCacheSrc = 'siPixelClusterShapeCachePreSplitting'
-initialStepSeedsPreSplitting.ClusterCheckPSet.PixelClusterCollectionLabel = 'siPixelClustersPreSplitting'
-
-eras.trackingPhase1.toModify(initialStepSeedsPreSplitting,
-    OrderedHitsFactoryPSet = cms.PSet(
-        ComponentName = cms.string("CombinedHitQuadrupletGenerator"),
-        GeneratorPSet = _PixelQuadrupletGenerator.clone(
-            extraHitRZtolerance = initialStepSeedsPreSplitting.OrderedHitsFactoryPSet.GeneratorPSet.extraHitRZtolerance,
-            extraHitRPhitolerance = initialStepSeedsPreSplitting.OrderedHitsFactoryPSet.GeneratorPSet.extraHitRPhitolerance,
-            SeedComparitorPSet = initialStepSeedsPreSplitting.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet,
-            maxChi2 = dict(
-                pt1    = 0.8, pt2    = 2,
-                value1 = 200, value2 = 100,
-                enabled = True,
-            ),
-            extraPhiTolerance = dict(
-                pt1    = 0.6, pt2    = 1,
-                value1 = 0.15, value2 = 0.1,
-                enabled = True,
-            ),
-            useBendingCorrection = True,
-            fitFastCircle = True,
-            fitFastCircleChi2Cut = True,
-        ),
-        TripletGeneratorPSet = initialStepSeedsPreSplitting.OrderedHitsFactoryPSet.GeneratorPSet,
-        SeedingLayers = cms.InputTag('initialStepSeedLayersPreSplitting'),
+# TrackingRegion
+from RecoTracker.TkTrackingRegions.globalTrackingRegionFromBeamSpot_cfi import globalTrackingRegionFromBeamSpot as _globalTrackingRegionFromBeamSpot
+initialStepTrackingRegionsPreSplitting = _globalTrackingRegionFromBeamSpot.clone(
+    RegionPSet = dict(
+        ptMin = 0.6,
+        originRadius = 0.02,
+        nSigmaZ = 4.0
     )
 )
+
+# seeding
+from RecoTracker.TkSeedGenerator.clusterCheckerEDProducer_cff import clusterCheckerEDProducer as _clusterCheckerEDProducer
+initialStepClusterCheckPreSplitting = _clusterCheckerEDProducer.clone(
+    PixelClusterCollectionLabel = 'siPixelClustersPreSplitting'
+)
+
+from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
+initialStepHitDoubletsPreSplitting = _hitPairEDProducer.clone(
+    seedingLayers = "initialStepSeedLayersPreSplitting",
+    trackingRegions = "initialStepTrackingRegionsPreSplitting",
+    clusterCheck = "initialStepClusterCheckPreSplitting",
+    produceIntermediateHitDoublets = True,
+)
+from RecoPixelVertexing.PixelTriplets.pixelTripletHLTEDProducer_cfi import pixelTripletHLTEDProducer as _pixelTripletHLTEDProducer
+from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
+import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
+initialStepHitTripletsPreSplitting = _pixelTripletHLTEDProducer.clone(
+    doublets = "initialStepHitDoubletsPreSplitting",
+    maxElement = 1000000,
+    produceSeedingHitSets = True,
+    SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor.clone(
+        clusterShapeCacheSrc = 'siPixelClusterShapeCachePreSplitting'
+    ),
+)
+from RecoPixelVertexing.PixelTriplets.pixelQuadrupletEDProducer_cfi import pixelQuadrupletEDProducer as _pixelQuadrupletEDProducer
+initialStepHitQuadrupletsPreSplitting = _pixelQuadrupletEDProducer.clone(
+    triplets = "initialStepHitTripletsPreSplitting",
+    extraHitRZtolerance = initialStepHitTripletsPreSplitting.extraHitRZtolerance,
+    extraHitRPhitolerance = initialStepHitTripletsPreSplitting.extraHitRPhitolerance,
+    maxChi2 = dict(
+        pt1    = 0.8, pt2    = 2,
+        value1 = 200, value2 = 100,
+        enabled = True,
+    ),
+    extraPhiTolerance = dict(
+        pt1    = 0.6, pt2    = 1,
+        value1 = 0.15, value2 = 0.1,
+        enabled = True,
+    ),
+    useBendingCorrection = True,
+    fitFastCircle = True,
+    fitFastCircleChi2Cut = True,
+    SeedComparitorPSet = initialStepHitTripletsPreSplitting.SeedComparitorPSet
+)
+from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_cfi import seedCreatorFromRegionConsecutiveHitsEDProducer as _seedCreatorFromRegionConsecutiveHitsEDProducer
+initialStepSeedsPreSplitting = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
+    seedingHitSets = "initialStepHitTripletsPreSplitting",
+)
+eras.trackingPhase1.toModify(initialStepHitTripletsPreSplitting,
+    produceSeedingHitSets = False,
+    produceIntermediateHitTriplets = True,
+)
+eras.trackingPhase1.toModify(initialStepSeedsPreSplitting, seedingHitSets = "initialStepHitQuadrupletsPreSplitting")
 
 
 # building
@@ -160,6 +177,10 @@ from RecoLocalTracker.SiPixelRecHits.SiPixelRecHits_cfi import siPixelRecHits
 from RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi import MeasurementTrackerEvent
 from RecoPixelVertexing.PixelLowPtUtilities.siPixelClusterShapeCache_cfi import *
 InitialStepPreSplitting = cms.Sequence(initialStepSeedLayersPreSplitting*
+                                       initialStepTrackingRegionsPreSplitting*
+                                       initialStepClusterCheckPreSplitting*
+                                       initialStepHitDoubletsPreSplitting*
+                                       initialStepHitTripletsPreSplitting*
                                        initialStepSeedsPreSplitting*
                                        initialStepTrackCandidatesPreSplitting*
                                        initialStepTracksPreSplitting*
@@ -172,6 +193,10 @@ InitialStepPreSplitting = cms.Sequence(initialStepSeedLayersPreSplitting*
                                        siPixelRecHits*
                                        MeasurementTrackerEvent*
                                        siPixelClusterShapeCache)
+
+_InitialStepPreSplitting_trackingPhase1 = InitialStepPreSplitting.copy()
+_InitialStepPreSplitting_trackingPhase1.replace(initialStepHitTripletsPreSplitting, initialStepHitTripletsPreSplitting*initialStepHitQuadrupletsPreSplitting)
+eras.trackingPhase1.toReplaceWith(InitialStepPreSplitting, _InitialStepPreSplitting_trackingPhase1)
 
 # Although InitialStepPreSplitting is not really part of LowPU/Run1/Phase1PU70
 # tracking, we use it to get siPixelClusters and siPixelRecHits

--- a/RecoTracker/SpecialSeedGenerators/interface/CosmicTrackingRegion.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CosmicTrackingRegion.h
@@ -84,13 +84,11 @@ public:
   
   virtual TrackingRegion::ctfHits 
   hits(
-       const edm::Event& ev,  
        const edm::EventSetup& es, 
        const ctfseeding::SeedingLayer* layer) const;
   
    TrackingRegion::Hits 
    hits(
-	const edm::Event& ev,
 	const edm::EventSetup& es,
 	const SeedingLayerSetsHits::SeedingLayer& layer) const override;
   
@@ -108,7 +106,6 @@ public:
 private:
   template <typename T>
   void hits_(
-      const edm::Event& ev,
       const edm::EventSetup& es,
       const T& layer, TrackingRegion::Hits & result) const;
 

--- a/RecoTracker/SpecialSeedGenerators/src/BeamHaloPairGenerator.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/BeamHaloPairGenerator.cc
@@ -26,8 +26,8 @@ const OrderedSeedingHits& BeamHaloPairGenerator::run(const TrackingRegion& regio
         if(layers.numberOfLayersInSet() != 2)
           throw cms::Exception("CtfSpecialSeedGenerator") << "You are using " << layers.numberOfLayersInSet() <<" layers in set instead of 2 ";
         for(SeedingLayerSetsHits::SeedingLayerSet ls: layers) {
-		auto innerHits  = region.hits(e, es, ls[0]);
-		auto outerHits  = region.hits(e, es, ls[1]);
+		auto innerHits  = region.hits(es, ls[0]);
+		auto outerHits  = region.hits(es, ls[1]);
 		
 		for (auto iOuterHit = outerHits.begin(); iOuterHit != outerHits.end(); iOuterHit++){
 		  for (auto iInnerHit = innerHits.begin(); iInnerHit != innerHits.end(); iInnerHit++){

--- a/RecoTracker/SpecialSeedGenerators/src/CosmicTrackingRegion.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CosmicTrackingRegion.cc
@@ -23,31 +23,27 @@ using namespace std;
 using namespace ctfseeding; 
 
 
-TrackingRegion::ctfHits CosmicTrackingRegion::hits(const edm::Event& ev,
-						const edm::EventSetup& es,
+TrackingRegion::ctfHits CosmicTrackingRegion::hits(const edm::EventSetup& es,
 						const  ctfseeding::SeedingLayer* layer) const
 {
   TrackingRegion::ctfHits result;
   TrackingRegion::Hits tmp;
-  hits_(ev, es, *layer, tmp);
+  hits_(es, *layer, tmp);
   result.reserve(tmp.size());
   for ( auto h : tmp) result.emplace_back(*h); // not owned
   return result;
 }
 
-TrackingRegion::Hits CosmicTrackingRegion::hits(const edm::Event& ev,
-						const edm::EventSetup& es,
+TrackingRegion::Hits CosmicTrackingRegion::hits(const edm::EventSetup& es,
 						const SeedingLayerSetsHits::SeedingLayer& layer) const
 {
   TrackingRegion::Hits result;
-  hits_(ev, es, layer, result);
+  hits_(es, layer, result);
   return result;
 }
 
 template <typename T>
-void CosmicTrackingRegion::hits_(
-				 const edm::Event& ev,
-				 const edm::EventSetup& es,
+void CosmicTrackingRegion::hits_(const edm::EventSetup& es,
 				 const T& layer, TrackingRegion::Hits  & result) const
 {
 

--- a/RecoTracker/SpecialSeedGenerators/src/GenericPairGenerator.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/GenericPairGenerator.cc
@@ -26,8 +26,8 @@ const OrderedSeedingHits& GenericPairGenerator::run(const TrackingRegion& region
           throw cms::Exception("CtfSpecialSeedGenerator") << "You are using " << layers.numberOfLayersInSet() <<" layers in set instead of 2 ";
 
         for(SeedingLayerSetsHits::SeedingLayerSet ls: layers) {
-		auto innerHits  = region.hits(e, es, ls[0]);
-		auto outerHits  = region.hits(e, es, ls[1]);
+		auto innerHits  = region.hits(es, ls[0]);
+		auto outerHits  = region.hits(es, ls[1]);
 		for (auto iOuterHit = outerHits.begin(); iOuterHit != outerHits.end(); iOuterHit++){
 		  for (auto iInnerHit = innerHits.begin(); iInnerHit != innerHits.end(); iInnerHit++){
 		    hitPairs.push_back(OrderedHitPair(&(**iInnerHit),

--- a/RecoTracker/SpecialSeedGenerators/src/GenericTripletGenerator.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/GenericTripletGenerator.cc
@@ -27,11 +27,11 @@ const OrderedSeedingHits& GenericTripletGenerator::run(const TrackingRegion& reg
           throw cms::Exception("CtfSpecialSeedGenerator") << "You are using " << layers.numberOfLayersInSet() <<" layers in set instead of 3 ";
 	std::map<float, OrderedHitTriplet> radius_triplet_map;
         for(SeedingLayerSetsHits::SeedingLayerSet ls: layers) {
-		auto innerHits  = region.hits(e, es, ls[0]);
+		auto innerHits  = region.hits(es, ls[0]);
 		//std::cout << "innerHits.size()=" << innerHits.size() << std::endl;
-		auto middleHits = region.hits(e, es, ls[1]);
+		auto middleHits = region.hits(es, ls[1]);
 		//std::cout << "middleHits.size()=" << middleHits.size() << std::endl;
-		auto outerHits  = region.hits(e, es, ls[2]);
+		auto outerHits  = region.hits(es, ls[2]);
 		//std::cout << "outerHits.size()=" << outerHits.size() << std::endl;
 		//std::cout << "trying " << innerHits.size()*middleHits.size()*outerHits.size() << " combinations "<<std::endl;
 		for (auto iOuterHit = outerHits.begin(); iOuterHit != outerHits.end(); iOuterHit++){

--- a/RecoTracker/SpecialSeedGenerators/src/SimpleCosmicBONSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/SimpleCosmicBONSeeder.cc
@@ -188,9 +188,9 @@ bool SimpleCosmicBONSeeder::triplets(const edm::Event& e, const edm::EventSetup&
     for(SeedingLayerSetsHits::LayerSetIndex layerIndex=0; layerIndex < layers.size(); ++layerIndex) {
         SeedingLayerSetsHits::SeedingLayerSet ls = layers[layerIndex];
         /// ctfseeding SeedinHits and their iterators
-        auto innerHits  = region_.hits(e, es, ls[0]);
-        auto middleHits = region_.hits(e, es, ls[1]);
-        auto outerHits  = region_.hits(e, es, ls[2]);
+        auto innerHits  = region_.hits(es, ls[0]);
+        auto middleHits = region_.hits(es, ls[1]);
+        auto outerHits  = region_.hits(es, ls[2]);
 
         if (tripletsVerbosity_ > 0) {
             std::cout << "GenericTripletGenerator iLss = " << seedingLayersToString(ls)

--- a/RecoTracker/TkHitPairs/BuildFile.xml
+++ b/RecoTracker/TkHitPairs/BuildFile.xml
@@ -2,6 +2,7 @@
 
 <use   name="clhep"/>
 <use   name="boost"/>
+<use   name="root"/>
 <use   name="RecoTracker/Record"/>
 <use   name="RecoTracker/TkDetLayers"/>
 <use   name="FWCore/ParameterSet"/>

--- a/RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h
+++ b/RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h
@@ -24,9 +24,23 @@ public:
   ~HitPairGeneratorFromLayerPair();
 
   HitDoublets doublets( const TrackingRegion& reg,
-                        const edm::Event & ev,  const edm::EventSetup& es, Layers layers);
+                        const edm::Event & ev,  const edm::EventSetup& es, Layers layers) {
+    assert(theLayerCache);
+    return doublets(reg, ev, es, layers, *theLayerCache);
+  }
   HitDoublets doublets( const TrackingRegion& reg,
-                        const edm::Event & ev,  const edm::EventSetup& es, const Layer& innerLayer, const Layer& outerLayer);
+                        const edm::Event & ev,  const edm::EventSetup& es, const Layer& innerLayer, const Layer& outerLayer) {
+    assert(theLayerCache);
+    return doublets(reg, ev, es, innerLayer, outerLayer, *theLayerCache);
+  }
+  HitDoublets doublets( const TrackingRegion& reg,
+                        const edm::Event & ev, const edm::EventSetup& es, Layers layers, LayerCacheType& layerCache) {
+    Layer innerLayerObj = innerLayer(layers);
+    Layer outerLayerObj = outerLayer(layers);
+    return doublets(reg, ev, es, innerLayerObj, outerLayerObj, layerCache);
+  }
+  HitDoublets doublets( const TrackingRegion& reg,
+                        const edm::Event & ev,  const edm::EventSetup& es, const Layer& innerLayer, const Layer& outerLayer, LayerCacheType& layerCache);
   
   void hitPairs( const TrackingRegion& reg, OrderedHitPairs & prs,
                  const edm::Event & ev,  const edm::EventSetup& es, Layers layers);
@@ -46,7 +60,7 @@ public:
   Layer outerLayer(const Layers& layers) const { return layers[theOuterLayer]; }
 
 private:
-  LayerCacheType & theLayerCache;
+  LayerCacheType *theLayerCache;
   const unsigned int theOuterLayer;
   const unsigned int theInnerLayer;
   const unsigned int theMaxElement;

--- a/RecoTracker/TkHitPairs/interface/IntermediateHitDoublets.h
+++ b/RecoTracker/TkHitPairs/interface/IntermediateHitDoublets.h
@@ -1,0 +1,171 @@
+#ifndef RecoTracker_TkHitPairs_IntermediateHitDoublets_h
+#define RecoTracker_TkHitPairs_IntermediateHitDoublets_h
+
+#include "RecoTracker/TkHitPairs/interface/LayerHitMapCache.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
+
+namespace ihd {
+  class RegionIndex {
+  public:
+    RegionIndex(const TrackingRegion *reg, unsigned int ind):
+      region_(reg),
+      layerSetBeginIndex_(ind),
+      layerSetEndIndex_(ind)
+    {}
+
+    void setLayerSetsEnd(unsigned int end) { layerSetEndIndex_ = end; }
+
+    const TrackingRegion& region() const { return *region_; }
+    unsigned int layerSetBeginIndex() const { return layerSetBeginIndex_; }
+    unsigned int layerSetEndIndex() const { return layerSetEndIndex_; }
+
+  private:
+    const TrackingRegion *region_;
+    unsigned int layerSetBeginIndex_; /// index to doublets_, pointing to the beginning of the layer pairs of this region
+    unsigned int layerSetEndIndex_;   /// index to doublets_, pointing to the end of the layer pairs of this region
+  };
+
+  template <typename T>
+  class RegionLayerHits {
+  public:
+    using const_iterator = typename std::vector<T>::const_iterator;
+
+    RegionLayerHits(const TrackingRegion* region, const_iterator begin, const_iterator end):
+      region_(region), layerSetsBegin_(begin), layerSetsEnd_(end) {}
+
+    const TrackingRegion& region() const { return *region_; }
+
+    const_iterator begin() const { return layerSetsBegin_; }
+    const_iterator cbegin() const { return begin(); }
+    const_iterator end() const { return layerSetsEnd_; }
+    const_iterator cend() const { return end(); }
+
+  private:
+    const TrackingRegion *region_;
+    const const_iterator layerSetsBegin_;
+    const const_iterator layerSetsEnd_;
+  };
+
+  template<typename ValueType, typename HitSetType>
+  class const_iterator {
+  public:
+    using internal_iterator_type = typename std::vector<RegionIndex>::const_iterator;
+    using value_type = ValueType;
+    using difference_type = internal_iterator_type::difference_type;
+
+    const_iterator(const HitSetType *hst, internal_iterator_type iter): hitSets_(hst), iter_(iter) {}
+
+    value_type operator*() const {
+      return value_type(&(iter_->region()),
+                        hitSets_->layerSetsBegin() + iter_->layerSetBeginIndex(),
+                        hitSets_->layerSetsBegin() + iter_->layerSetEndIndex());
+    }
+
+    const_iterator& operator++() { ++iter_; return *this; }
+    const_iterator operator++(int) {
+      const_iterator clone(*this);
+      ++iter_;
+      return clone;
+    }
+
+    bool operator==(const const_iterator& other) const { return iter_ == other.iter_; }
+    bool operator!=(const const_iterator& other) const { return !operator==(other); }
+
+  private:
+    const HitSetType *hitSets_;
+    internal_iterator_type iter_;
+  };
+}
+
+/**
+ * Simple container of temporary information delivered from hit pair
+ * generator to hit triplet generator via edm::Event.
+ */
+class IntermediateHitDoublets {
+public:
+  using LayerPair = std::tuple<SeedingLayerSetsHits::LayerIndex, SeedingLayerSetsHits::LayerIndex>;
+  using RegionIndex = ihd::RegionIndex;
+
+  class LayerPairHitDoublets {
+  public:
+    LayerPairHitDoublets(const SeedingLayerSetsHits::SeedingLayerSet& layerSet, HitDoublets&& doublets, LayerHitMapCache&& cache):
+      layerPair_(layerSet[0].index(), layerSet[1].index()),
+      doublets_(std::move(doublets)),
+      cache_(std::move(cache))
+    {}
+
+    SeedingLayerSetsHits::LayerIndex innerLayerIndex() const { return std::get<0>(layerPair_); }
+    SeedingLayerSetsHits::LayerIndex outerLayerIndex() const { return std::get<1>(layerPair_); }
+
+    const HitDoublets& doublets() const { return doublets_; }
+    const LayerHitMapCache& cache() const { return cache_; }
+
+  private:
+    LayerPair layerPair_;
+    HitDoublets doublets_;
+    LayerHitMapCache cache_;
+  };
+
+  ////////////////////
+
+  using RegionLayerHits = ihd::RegionLayerHits<LayerPairHitDoublets>;
+
+  ////////////////////
+
+  using const_iterator = ihd::const_iterator<RegionLayerHits, IntermediateHitDoublets>;
+
+  ////////////////////
+
+  IntermediateHitDoublets(): seedingLayers_(nullptr) {}
+  explicit IntermediateHitDoublets(const SeedingLayerSetsHits *seedingLayers): seedingLayers_(seedingLayers) {}
+  IntermediateHitDoublets(const IntermediateHitDoublets& rh); // only to make ROOT dictionary generation happy
+  ~IntermediateHitDoublets() = default;
+
+  void swap(IntermediateHitDoublets& rh) {
+    std::swap(seedingLayers_, rh.seedingLayers_);
+    std::swap(regions_, rh.regions_);
+    std::swap(layerPairs_, rh.layerPairs_);
+  }
+
+  void reserve(size_t nregions, size_t nlayersets) {
+    regions_.reserve(nregions);
+    layerPairs_.reserve(nregions*nlayersets);
+  }
+
+  void shrink_to_fit() {
+    regions_.shrink_to_fit();
+    layerPairs_.shrink_to_fit();
+  }
+
+  void beginRegion(const TrackingRegion *region) {
+    regions_.emplace_back(region, layerPairs_.size());
+  }
+
+  void addDoublets(const SeedingLayerSetsHits::SeedingLayerSet& layerSet, HitDoublets&& doublets, LayerHitMapCache&& cache) {
+    layerPairs_.emplace_back(layerSet, std::move(doublets), std::move(cache));
+    regions_.back().setLayerSetsEnd(layerPairs_.size());
+  }
+
+  const SeedingLayerSetsHits& seedingLayerHits() const { return *seedingLayers_; }
+  size_t regionSize() const { return regions_.size(); }
+  size_t layerPairsSize() const { return layerPairs_.size(); }
+
+  const_iterator begin() const { return const_iterator(this, regions_.begin()); }
+  const_iterator cbegin() const { return begin(); }
+  const_iterator end() const { return const_iterator(this, regions_.end()); }
+  const_iterator cend() const { return end(); }
+
+  // used internally
+  std::vector<RegionIndex>::const_iterator regionsBegin() const { return regions_.begin(); }
+  std::vector<RegionIndex>::const_iterator regionsEnd() const { return regions_.end(); }
+  std::vector<LayerPairHitDoublets>::const_iterator layerSetsBegin() const { return layerPairs_.begin(); }
+  std::vector<LayerPairHitDoublets>::const_iterator layerSetsEnd() const { return layerPairs_.end(); }
+
+private:
+  const SeedingLayerSetsHits *seedingLayers_;
+
+  std::vector<RegionIndex> regions_;
+  std::vector<LayerPairHitDoublets> layerPairs_;
+};
+
+#endif

--- a/RecoTracker/TkHitPairs/interface/IntermediateHitDoublets.h
+++ b/RecoTracker/TkHitPairs/interface/IntermediateHitDoublets.h
@@ -151,6 +151,7 @@ public:
   }
 
   const SeedingLayerSetsHits& seedingLayerHits() const { return *seedingLayers_; }
+  bool empty() const { return regions_.empty(); }
   size_t regionSize() const { return regions_.size(); }
   size_t layerPairsSize() const { return layerPairs_.size(); }
 

--- a/RecoTracker/TkHitPairs/interface/IntermediateHitDoublets.h
+++ b/RecoTracker/TkHitPairs/interface/IntermediateHitDoublets.h
@@ -30,7 +30,9 @@ namespace ihd {
   public:
     using const_iterator = typename std::vector<T>::const_iterator;
 
-    RegionLayerHits(const TrackingRegion* region, const_iterator begin, const_iterator end):
+    // Taking T* to have compatible interface with IntermediateHitTriplets::RegionLayerHits
+    template <typename TMP>
+    RegionLayerHits(const TrackingRegion* region, const TMP*, const_iterator begin, const_iterator end):
       region_(region), layerSetsBegin_(begin), layerSetsEnd_(end) {}
 
     const TrackingRegion& region() const { return *region_; }
@@ -57,6 +59,7 @@ namespace ihd {
 
     value_type operator*() const {
       return value_type(&(iter_->region()),
+                        hitSets_,
                         hitSets_->layerSetsBegin() + iter_->layerSetBeginIndex(),
                         hitSets_->layerSetsBegin() + iter_->layerSetEndIndex());
     }

--- a/RecoTracker/TkHitPairs/interface/IntermediateHitDoublets.h
+++ b/RecoTracker/TkHitPairs/interface/IntermediateHitDoublets.h
@@ -94,6 +94,7 @@ public:
       cache_(std::move(cache))
     {}
 
+    const LayerPair& layerPair() const { return layerPair_; }
     SeedingLayerSetsHits::LayerIndex innerLayerIndex() const { return std::get<0>(layerPair_); }
     SeedingLayerSetsHits::LayerIndex outerLayerIndex() const { return std::get<1>(layerPair_); }
 

--- a/RecoTracker/TkHitPairs/interface/LayerHitMapCache.h
+++ b/RecoTracker/TkHitPairs/interface/LayerHitMapCache.h
@@ -25,7 +25,7 @@ private:
     void resize(int size) { theContainer.resize(size,nullptr); }
     const ValueType*  get(KeyType key) { return theContainer[key];}
     /// add object to cache. It is caller responsibility to check that object is not yet there.
-    void add(KeyType key, const ValueType * value) {
+    void add(KeyType key, ValueType * value) {
       if (key>=int(theContainer.size())) resize(key+1);
       theContainer[key]=value;
     }
@@ -54,10 +54,11 @@ public:
     assert (key>=0);
     const RecHitsSortedInPhi * lhm = theCache.get(key);
     if (lhm==nullptr) {
-      lhm=new RecHitsSortedInPhi (region.hits(iSetup,layer), region.origin(), layer.detLayer());
-      lhm->theOrigin = region.origin();
+      auto tmp=new RecHitsSortedInPhi (region.hits(iSetup,layer), region.origin(), layer.detLayer());
+      tmp->theOrigin = region.origin();
+      theCache.add( key, tmp);
+      lhm = tmp;
       LogDebug("LayerHitMapCache")<<" I got"<< lhm->all().second-lhm->all().first<<" hits in the cache for: "<<layer.detLayer();
-      theCache.add( key, lhm);
     }
     else{
       // std::cout << region.origin() << " " <<  lhm->theOrigin << std::endl;

--- a/RecoTracker/TkHitPairs/interface/LayerHitMapCache.h
+++ b/RecoTracker/TkHitPairs/interface/LayerHitMapCache.h
@@ -47,12 +47,12 @@ public:
   
   const RecHitsSortedInPhi &
   operator()(const SeedingLayerSetsHits::SeedingLayer& layer, const TrackingRegion & region,
-	     const edm::Event & iEvent, const edm::EventSetup & iSetup) {
+	     const edm::EventSetup & iSetup) {
     int key = layer.index();
     assert (key>=0);
     const RecHitsSortedInPhi * lhm = theCache.get(key);
     if (lhm==nullptr) {
-      lhm=new RecHitsSortedInPhi (region.hits(iEvent,iSetup,layer), region.origin(), layer.detLayer());
+      lhm=new RecHitsSortedInPhi (region.hits(iSetup,layer), region.origin(), layer.detLayer());
       lhm->theOrigin = region.origin();
       LogDebug("LayerHitMapCache")<<" I got"<< lhm->all().second-lhm->all().first<<" hits in the cache for: "<<layer.detLayer();
       theCache.add( key, lhm);

--- a/RecoTracker/TkHitPairs/interface/LayerHitMapCache.h
+++ b/RecoTracker/TkHitPairs/interface/LayerHitMapCache.h
@@ -20,6 +20,7 @@ private:
     using ValueType = RecHitsSortedInPhi;
     using KeyType = int;
     SimpleCache(unsigned int initSize) : theContainer(initSize, nullptr){}
+    SimpleCache(SimpleCache&& rh): theContainer(std::move(rh.theContainer)) {}
     ~SimpleCache() { clear(); }
     void resize(int size) { theContainer.resize(size,nullptr); }
     const ValueType*  get(KeyType key) { return theContainer[key];}
@@ -42,6 +43,7 @@ private:
   typedef SimpleCache Cache;
 public:
   LayerHitMapCache(unsigned int initSize=50) : theCache(initSize) { }
+  LayerHitMapCache(LayerHitMapCache&& rh): theCache(std::move(rh.theCache)) {}
 
   void clear() { theCache.clear(); }
   

--- a/RecoTracker/TkHitPairs/interface/RecHitsSortedInPhi.h
+++ b/RecoTracker/TkHitPairs/interface/RecHitsSortedInPhi.h
@@ -91,7 +91,7 @@ public:
 
 public:
 
-  mutable GlobalPoint theOrigin;
+  GlobalPoint theOrigin;
 
   std::vector<HitWithPhi> theHits;
 

--- a/RecoTracker/TkHitPairs/interface/RegionsSeedingHitSets.h
+++ b/RecoTracker/TkHitPairs/interface/RegionsSeedingHitSets.h
@@ -10,6 +10,9 @@ class RegionsSeedingHitSets {
 public:
   using RegionIndex = ihd::RegionIndex;
 
+  using RegionSeedingHitSets = ihd::RegionLayerHits<SeedingHitSet>;
+  using const_iterator = ihd::const_iterator<RegionSeedingHitSets, RegionsSeedingHitSets>;
+
   // helper class to enforce correct usage
   class RegionFiller {
   public:
@@ -58,6 +61,15 @@ public:
 
   size_t regionSize() const { return regions_.size(); }
   size_t size() const { return hitSets_.size(); }
+
+  const_iterator begin() const { return const_iterator(this, regions_.begin()); }
+  const_iterator cbegin() const { return begin(); }
+  const_iterator end() const { return const_iterator(this, regions_.end()); }
+  const_iterator cend() const { return end(); }
+
+  // Used internally
+  std::vector<SeedingHitSet>::const_iterator layerSetsBegin() const { return hitSets_.begin(); }
+  std::vector<SeedingHitSet>::const_iterator layerSetsEnd() const { return hitSets_.end(); }
 
 private:
   std::vector<RegionIndex> regions_;

--- a/RecoTracker/TkHitPairs/interface/RegionsSeedingHitSets.h
+++ b/RecoTracker/TkHitPairs/interface/RegionsSeedingHitSets.h
@@ -1,0 +1,67 @@
+#ifndef RecoTracker_TkHitPairs_RegionsSeedingHitSets_H
+#define RecoTracker_TkHitPairs_RegionsSeedingHitSets_H
+
+#include "RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h"
+#include "RecoTracker/TkHitPairs/interface/IntermediateHitDoublets.h"
+
+// defined in this package instead of RecoTracker/TkSeedingLayers to avoid circular dependencies
+
+class RegionsSeedingHitSets {
+public:
+  using RegionIndex = ihd::RegionIndex;
+
+  // helper class to enforce correct usage
+  class RegionFiller {
+  public:
+    RegionFiller(): obj_(nullptr) {}
+    explicit RegionFiller(RegionsSeedingHitSets* obj): obj_(obj) {}
+
+    ~RegionFiller() {
+      if(obj_) obj_->regions_.back().setLayerSetsEnd(obj_->hitSets_.size());
+    }
+
+    bool valid() const { return obj_ != nullptr; }
+
+    template <typename... Args>
+    void emplace_back(Args&&... args) {
+      obj_->hitSets_.emplace_back(std::forward<Args>(args)...);
+    }
+  private:
+    RegionsSeedingHitSets *obj_;
+  };
+
+  static RegionFiller dummyFiller() { return RegionFiller(); }
+
+  // constructors
+  RegionsSeedingHitSets() = default;
+  ~RegionsSeedingHitSets() = default;
+
+  void swap(RegionsSeedingHitSets& rh) {
+    regions_.swap(rh.regions_);
+    hitSets_.swap(rh.hitSets_);
+  }
+
+  void reserve(size_t nregions, size_t nhitsets) {
+    regions_.reserve(nregions);
+    hitSets_.reserve(nhitsets);
+  }
+
+  void shrink_to_fit() {
+    regions_.shrink_to_fit();
+    hitSets_.shrink_to_fit();
+  }
+
+  RegionFiller beginRegion(const TrackingRegion *region) {
+    regions_.emplace_back(region, hitSets_.size());
+    return RegionFiller(this);
+  }
+
+  size_t regionSize() const { return regions_.size(); }
+  size_t size() const { return hitSets_.size(); }
+
+private:
+  std::vector<RegionIndex> regions_;
+  std::vector<SeedingHitSet> hitSets_;
+};
+
+#endif

--- a/RecoTracker/TkHitPairs/plugins/BuildFile.xml
+++ b/RecoTracker/TkHitPairs/plugins/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="RecoTracker/TkHitPairs"/>
 <use   name="RecoTracker/TkTrackingRegions"/>
+<use   name="RecoPixelVertexing/PixelTriplets"/>
 <library   file="*.cc" name="RecoTrackerTkHitPairsPlugins">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/RecoTracker/TkHitPairs/plugins/HitPairEDProducer.cc
+++ b/RecoTracker/TkHitPairs/plugins/HitPairEDProducer.cc
@@ -63,7 +63,7 @@ void HitPairEDProducer::fillDescriptions(edm::ConfigurationDescriptions& descrip
   desc.add<edm::InputTag>("trackingRegions", edm::InputTag("globalTrackingRegionFromBeamSpot"));
   desc.add<bool>("produceSeedingHitSets", false);
   desc.add<bool>("produceIntermediateHitDoublets", false);
-  desc.add<unsigned int>("maxElement", 1000000);
+  desc.add<unsigned int>("maxElement", 0); // default is really 0? Also when used from CombinedHitTripletGenerator?
 
   descriptions.add("hitPairEDProducer", desc);
 }

--- a/RecoTracker/TkHitPairs/plugins/HitPairEDProducer.cc
+++ b/RecoTracker/TkHitPairs/plugins/HitPairEDProducer.cc
@@ -1,0 +1,127 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Utilities/interface/RunningAverage.h"
+
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
+#include "DataFormats/Common/interface/OwnVector.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
+#include "RecoTracker/TkHitPairs/interface/LayerHitMapCache.h"
+#include "RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h"
+#include "RecoTracker/TkHitPairs/interface/IntermediateHitDoublets.h"
+#include "RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h"
+
+class HitPairEDProducer: public edm::stream::EDProducer<> {
+public:
+  HitPairEDProducer(const edm::ParameterSet& iConfig);
+  ~HitPairEDProducer() = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  virtual void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+
+private:
+  edm::EDGetTokenT<SeedingLayerSetsHits> seedingLayerToken_;
+  edm::EDGetTokenT<edm::OwnVector<TrackingRegion> > regionToken_;
+
+  edm::RunningAverage localRA_;
+  LayerHitMapCache layerCache_;
+  const unsigned int maxElement_;
+
+  HitPairGeneratorFromLayerPair generator_;
+
+  const bool produceSeedingHitSets_;
+  const bool produceIntermediateHitDoublets_;
+};
+
+
+HitPairEDProducer::HitPairEDProducer(const edm::ParameterSet& iConfig):
+  seedingLayerToken_(consumes<SeedingLayerSetsHits>(iConfig.getParameter<edm::InputTag>("seedingLayers"))),
+  regionToken_(consumes<edm::OwnVector<TrackingRegion> >(iConfig.getParameter<edm::InputTag>("trackingRegions"))),
+  maxElement_(iConfig.getParameter<unsigned int>("maxElement")),
+  generator_(0, 1, nullptr, maxElement_), // TODO: make layer indices configurable?
+  produceSeedingHitSets_(iConfig.getParameter<bool>("produceSeedingHitSets")),
+  produceIntermediateHitDoublets_(iConfig.getParameter<bool>("produceIntermediateHitDoublets"))
+{
+  if(!produceIntermediateHitDoublets_ && !produceSeedingHitSets_)
+    throw cms::Exception("Configuration") << "HitPairEDProducer requires either produceIntermediateHitDoublets or produceSeedingHitSets to be True. If neither are needed, just remove this module from your sequence/path as it doesn't do anything useful";
+
+  if(produceSeedingHitSets_)
+    produces<std::vector<SeedingHitSet> >();
+  if(produceIntermediateHitDoublets_)
+    produces<IntermediateHitDoublets>();
+}
+
+void HitPairEDProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add<edm::InputTag>("seedingLayers", edm::InputTag("seedingLayersEDProducer"));
+  desc.add<edm::InputTag>("trackingRegions", edm::InputTag("globalTrackingRegionFromBeamSpot"));
+  desc.add<bool>("produceSeedingHitSets", false);
+  desc.add<bool>("produceIntermediateHitDoublets", false);
+  desc.add<unsigned int>("maxElement", 1000000);
+
+  descriptions.add("hitPairEDProducer", desc);
+}
+
+void HitPairEDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<SeedingLayerSetsHits> hlayers;
+  iEvent.getByToken(seedingLayerToken_, hlayers);
+  const auto& layers = *hlayers;
+  if(layers.numberOfLayersInSet() < 2)
+    throw cms::Exception("Configuration") << "HitPairEDProducer expects SeedingLayerSetsHits::numberOfLayersInSet() to be >= 2, got " << layers.numberOfLayersInSet();
+
+  edm::Handle<edm::OwnVector<TrackingRegion> > hregions;
+  iEvent.getByToken(regionToken_, hregions);
+  const auto& regions = *hregions;
+
+  std::unique_ptr<std::vector<SeedingHitSet> > seedingHitSets;
+  if(produceSeedingHitSets_) {
+    seedingHitSets = std::make_unique<std::vector<SeedingHitSet> >();
+    seedingHitSets->reserve(localRA_.upper());
+  }
+  std::unique_ptr<IntermediateHitDoublets> intermediateHitDoublets;
+  if(produceIntermediateHitDoublets_) {
+    intermediateHitDoublets = std::make_unique<IntermediateHitDoublets>(&layers);
+    intermediateHitDoublets->reserve(regions.size(), layers.size());
+  }
+
+  for(const TrackingRegion& region: regions) {
+    if(produceIntermediateHitDoublets_) {
+      intermediateHitDoublets->beginRegion(&region);
+    }
+
+    for(SeedingLayerSetsHits::SeedingLayerSet layerSet: layers) {
+      LayerHitMapCache hitCache;
+      auto doublets = generator_.doublets(region, iEvent, iSetup, layerSet, hitCache);
+      if(doublets.empty()) continue; // don't bother if no pairs from these layers
+      if(produceSeedingHitSets_) {
+        for(size_t i=0, size=doublets.size(); i<size; ++i) {
+          seedingHitSets->emplace_back(doublets.hit(i, HitDoublets::inner),
+                                       doublets.hit(i, HitDoublets::outer));
+        }
+      }
+      if(produceIntermediateHitDoublets_) {
+        intermediateHitDoublets->addDoublets(layerSet, std::move(doublets), std::move(hitCache));
+      }
+    }
+  }
+
+  if(produceSeedingHitSets_) {
+    seedingHitSets->shrink_to_fit();
+    localRA_.update(seedingHitSets->size());
+    iEvent.put(std::move(seedingHitSets));
+  }
+  if(produceIntermediateHitDoublets_) {
+    intermediateHitDoublets->shrink_to_fit();
+    iEvent.put(std::move(intermediateHitDoublets));
+  }
+}
+
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(HitPairEDProducer);

--- a/RecoTracker/TkHitPairs/src/HitPairGeneratorFromLayerPair.cc
+++ b/RecoTracker/TkHitPairs/src/HitPairGeneratorFromLayerPair.cc
@@ -34,7 +34,7 @@ HitPairGeneratorFromLayerPair::HitPairGeneratorFromLayerPair(
 							     unsigned int outer,
 							     LayerCacheType* layerCache,
 							     unsigned int max)
-  : theLayerCache(*layerCache), theOuterLayer(outer), theInnerLayer(inner), theMaxElement(max)
+  : theLayerCache(layerCache), theOuterLayer(outer), theInnerLayer(inner), theMaxElement(max)
 {
 }
 
@@ -87,41 +87,13 @@ void HitPairGeneratorFromLayerPair::hitPairs(
 }
 
 HitDoublets HitPairGeneratorFromLayerPair::doublets( const TrackingRegion& region,
-						    const edm::Event & iEvent, const edm::EventSetup& iSetup, Layers layers) {
+                                                     const edm::Event & iEvent, const edm::EventSetup& iSetup, const Layer& innerLayer, const Layer& outerLayer,
+                                                     LayerCacheType& layerCache) {
 
-  typedef OrderedHitPair::InnerRecHit InnerHit;
-  typedef OrderedHitPair::OuterRecHit OuterHit;
-  typedef RecHitsSortedInPhi::Hit Hit;
-
-  Layer innerLayerObj = innerLayer(layers);
-  Layer outerLayerObj = outerLayer(layers);
-
-  const RecHitsSortedInPhi & innerHitsMap = theLayerCache(innerLayerObj, region, iSetup);
+  const RecHitsSortedInPhi & innerHitsMap = layerCache(innerLayer, region, iSetup);
   if (innerHitsMap.empty()) return HitDoublets(innerHitsMap,innerHitsMap);
 
-  const RecHitsSortedInPhi& outerHitsMap = theLayerCache(outerLayerObj, region, iSetup);
-  if (outerHitsMap.empty()) return HitDoublets(innerHitsMap,outerHitsMap);
-  HitDoublets result(innerHitsMap,outerHitsMap); result.reserve(std::max(innerHitsMap.size(),outerHitsMap.size()));
-  doublets(region,
-	   *innerLayerObj.detLayer(),*outerLayerObj.detLayer(),
-	   innerHitsMap,outerHitsMap,iSetup,theMaxElement,result);
-  return result;
-
-}
-
-
-HitDoublets HitPairGeneratorFromLayerPair::doublets( const TrackingRegion& region,
-						    const edm::Event & iEvent, const edm::EventSetup& iSetup, const Layer& innerLayer, const Layer& outerLayer) {
-
-  typedef OrderedHitPair::InnerRecHit InnerHit;
-  typedef OrderedHitPair::OuterRecHit OuterHit;
-  typedef RecHitsSortedInPhi::Hit Hit;
-
-
-  const RecHitsSortedInPhi & innerHitsMap = theLayerCache(innerLayer, region, iSetup);
-  if (innerHitsMap.empty()) return HitDoublets(innerHitsMap,innerHitsMap);
-
-  const RecHitsSortedInPhi& outerHitsMap = theLayerCache(outerLayer, region, iSetup);
+  const RecHitsSortedInPhi& outerHitsMap = layerCache(outerLayer, region, iSetup);
   if (outerHitsMap.empty()) return HitDoublets(innerHitsMap,outerHitsMap);
   HitDoublets result(innerHitsMap,outerHitsMap); result.reserve(std::max(innerHitsMap.size(),outerHitsMap.size()));
   doublets(region,

--- a/RecoTracker/TkHitPairs/src/HitPairGeneratorFromLayerPair.cc
+++ b/RecoTracker/TkHitPairs/src/HitPairGeneratorFromLayerPair.cc
@@ -96,10 +96,10 @@ HitDoublets HitPairGeneratorFromLayerPair::doublets( const TrackingRegion& regio
   Layer innerLayerObj = innerLayer(layers);
   Layer outerLayerObj = outerLayer(layers);
 
-  const RecHitsSortedInPhi & innerHitsMap = theLayerCache(innerLayerObj, region, iEvent, iSetup);
+  const RecHitsSortedInPhi & innerHitsMap = theLayerCache(innerLayerObj, region, iSetup);
   if (innerHitsMap.empty()) return HitDoublets(innerHitsMap,innerHitsMap);
 
-  const RecHitsSortedInPhi& outerHitsMap = theLayerCache(outerLayerObj, region, iEvent, iSetup);
+  const RecHitsSortedInPhi& outerHitsMap = theLayerCache(outerLayerObj, region, iSetup);
   if (outerHitsMap.empty()) return HitDoublets(innerHitsMap,outerHitsMap);
   HitDoublets result(innerHitsMap,outerHitsMap); result.reserve(std::max(innerHitsMap.size(),outerHitsMap.size()));
   doublets(region,
@@ -118,10 +118,10 @@ HitDoublets HitPairGeneratorFromLayerPair::doublets( const TrackingRegion& regio
   typedef RecHitsSortedInPhi::Hit Hit;
 
 
-  const RecHitsSortedInPhi & innerHitsMap = theLayerCache(innerLayer, region, iEvent, iSetup);
+  const RecHitsSortedInPhi & innerHitsMap = theLayerCache(innerLayer, region, iSetup);
   if (innerHitsMap.empty()) return HitDoublets(innerHitsMap,innerHitsMap);
 
-  const RecHitsSortedInPhi& outerHitsMap = theLayerCache(outerLayer, region, iEvent, iSetup);
+  const RecHitsSortedInPhi& outerHitsMap = theLayerCache(outerLayer, region, iSetup);
   if (outerHitsMap.empty()) return HitDoublets(innerHitsMap,outerHitsMap);
   HitDoublets result(innerHitsMap,outerHitsMap); result.reserve(std::max(innerHitsMap.size(),outerHitsMap.size()));
   doublets(region,

--- a/RecoTracker/TkHitPairs/src/IntermediateHitDoublets.cc
+++ b/RecoTracker/TkHitPairs/src/IntermediateHitDoublets.cc
@@ -1,0 +1,7 @@
+#include "RecoTracker/TkHitPairs/interface/IntermediateHitDoublets.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+IntermediateHitDoublets::IntermediateHitDoublets(const IntermediateHitDoublets& rh) {
+  throw cms::Exception("Not Implemented") << "The copy constructor of IntermediateHitDoublets should never be called. The function exists only to make ROOT dictionary generation happy.";
+}
+

--- a/RecoTracker/TkHitPairs/src/classes.h
+++ b/RecoTracker/TkHitPairs/src/classes.h
@@ -1,0 +1,11 @@
+#include "RecoTracker/TkHitPairs/interface/IntermediateHitDoublets.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+
+#include <vector>
+
+namespace RecoTracker_TkHitPairs {
+  struct dictionary {
+    IntermediateHitDoublets ihd;
+    edm::Wrapper<IntermediateHitDoublets> wihd;
+  };
+}

--- a/RecoTracker/TkHitPairs/src/classes.h
+++ b/RecoTracker/TkHitPairs/src/classes.h
@@ -1,4 +1,5 @@
 #include "RecoTracker/TkHitPairs/interface/IntermediateHitDoublets.h"
+#include "RecoTracker/TkHitPairs/interface/RegionsSeedingHitSets.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
 #include <vector>
@@ -7,5 +8,8 @@ namespace RecoTracker_TkHitPairs {
   struct dictionary {
     IntermediateHitDoublets ihd;
     edm::Wrapper<IntermediateHitDoublets> wihd;
+
+    RegionsSeedingHitSets rshs;
+    edm::Wrapper<RegionsSeedingHitSets> wrshs;
   };
 }

--- a/RecoTracker/TkHitPairs/src/classes_def.xml
+++ b/RecoTracker/TkHitPairs/src/classes_def.xml
@@ -1,0 +1,4 @@
+<lcgdict>
+  <class name="IntermediateHitDoublets" persistent="false"/>
+  <class name="edm::Wrapper<IntermediateHitDoublets>" persistent="false"/>
+</lcgdict>

--- a/RecoTracker/TkHitPairs/src/classes_def.xml
+++ b/RecoTracker/TkHitPairs/src/classes_def.xml
@@ -1,4 +1,6 @@
 <lcgdict>
   <class name="IntermediateHitDoublets" persistent="false"/>
   <class name="edm::Wrapper<IntermediateHitDoublets>" persistent="false"/>
+  <class name="RegionsSeedingHitSets" persistent="false"/>
+  <class name="edm::Wrapper<RegionsSeedingHitSets>" persistent="false"/>
 </lcgdict>

--- a/RecoTracker/TkSeedGenerator/interface/ClusterChecker.h
+++ b/RecoTracker/TkSeedGenerator/interface/ClusterChecker.h
@@ -7,13 +7,7 @@
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#else
-namespace edm {
-	class ConsumesCollector;
-}
-#endif
 
 namespace edm { class Event; class ParameterSet; }
 
@@ -29,10 +23,8 @@ namespace reco { namespace utils {
 
 class ClusterChecker {
  public: 
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
   ClusterChecker(const edm::ParameterSet & conf, edm::ConsumesCollector & iC) ;
   ClusterChecker(const edm::ParameterSet & conf, edm::ConsumesCollector && iC) ;
-#endif
 
   ~ClusterChecker() ;
   size_t tooManyClusters(const edm::Event & e) const ;
@@ -46,10 +38,8 @@ class ClusterChecker {
   unsigned int maxNrOfPixelClusters_;
   StringCutObjectSelector<reco::utils::ClusterTotals> selector_;
   unsigned int ignoreDetsAboveNClusters_;
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
   edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > token_sc;
   edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > token_pc;
-#endif
 };
 
 #endif

--- a/RecoTracker/TkSeedGenerator/interface/ClusterChecker.h
+++ b/RecoTracker/TkSeedGenerator/interface/ClusterChecker.h
@@ -9,7 +9,7 @@
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
-namespace edm { class Event; class ParameterSet; }
+namespace edm { class Event; class ParameterSet; class ParameterSetDescription; }
 
 namespace reco { namespace utils {
     struct ClusterTotals {
@@ -25,6 +25,8 @@ class ClusterChecker {
  public: 
   ClusterChecker(const edm::ParameterSet & conf, edm::ConsumesCollector & iC) ;
   ClusterChecker(const edm::ParameterSet & conf, edm::ConsumesCollector && iC) ;
+
+  static void fillDescriptions(edm::ParameterSetDescription& description);
 
   ~ClusterChecker() ;
   size_t tooManyClusters(const edm::Event & e) const ;

--- a/RecoTracker/TkSeedGenerator/interface/SeedCreatorFromRegionHitsEDProducerT.h
+++ b/RecoTracker/TkSeedGenerator/interface/SeedCreatorFromRegionHitsEDProducerT.h
@@ -1,0 +1,95 @@
+#ifndef RecoTracker_TkSeedGenerator_SeedCreatorFromRegionHitsEDProducerT_H
+#define RecoTracker_TkSeedGenerator_SeedCreatorFromRegionHitsEDProducerT_H
+
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "DataFormats/Common/interface/Handle.h"
+
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "RecoTracker/TkSeedingLayers/interface/SeedComparitorFactory.h"
+#include "RecoTracker/TkSeedingLayers/interface/SeedComparitor.h"
+
+#include "RecoTracker/TkHitPairs/interface/RegionsSeedingHitSets.h"
+
+template <typename T_SeedCreator>
+class SeedCreatorFromRegionHitsEDProducerT: public edm::stream::EDProducer<> {
+public:
+
+  SeedCreatorFromRegionHitsEDProducerT(const edm::ParameterSet& iConfig);
+  ~SeedCreatorFromRegionHitsEDProducerT() = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  virtual void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+
+private:
+  edm::EDGetTokenT<RegionsSeedingHitSets> seedingHitSetsToken_;
+  T_SeedCreator seedCreator_;
+  std::unique_ptr<SeedComparitor> comparitor_;
+};
+
+template <typename T_SeedCreator>
+SeedCreatorFromRegionHitsEDProducerT<T_SeedCreator>::SeedCreatorFromRegionHitsEDProducerT(const edm::ParameterSet& iConfig):
+  seedingHitSetsToken_(consumes<RegionsSeedingHitSets>(iConfig.getParameter<edm::InputTag>("seedingHitSets"))),
+  seedCreator_(iConfig)
+{
+  edm::ConsumesCollector iC = consumesCollector();
+  edm::ParameterSet comparitorPSet = iConfig.getParameter<edm::ParameterSet>("SeedComparitorPSet");
+  std::string comparitorName = comparitorPSet.getParameter<std::string>("ComponentName");
+  comparitor_.reset((comparitorName == "none") ? nullptr : SeedComparitorFactory::get()->create(comparitorName, comparitorPSet, iC));
+
+  produces<TrajectorySeedCollection>();
+}
+
+template <typename T_SeedCreator>
+void SeedCreatorFromRegionHitsEDProducerT<T_SeedCreator>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add<edm::InputTag>("seedingHitSets", edm::InputTag("hitPairEDProducer"));
+  T_SeedCreator::fillDescriptions(desc);
+
+  edm::ParameterSetDescription descComparitor;
+  descComparitor.add<std::string>("ComponentName", "none");
+  descComparitor.setAllowAnything(); // until we have moved SeedComparitor too to EDProducers
+  desc.add<edm::ParameterSetDescription>("SeedComparitorPSet", descComparitor);
+
+  auto label = std::string("seedCreatorFromRegion") + T_SeedCreator::fillDescriptionsLabel() + "EDProducer";
+  descriptions.add(label, desc);
+}
+
+template <typename T_SeedCreator>
+void SeedCreatorFromRegionHitsEDProducerT<T_SeedCreator>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<RegionsSeedingHitSets> hseedingHitSets;
+  iEvent.getByToken(seedingHitSetsToken_, hseedingHitSets);
+  const auto& seedingHitSets = *hseedingHitSets;
+
+  auto seeds = std::make_unique<TrajectorySeedCollection>();
+  seeds->reserve(seedingHitSets.size());
+
+  if(comparitor_)
+    comparitor_->init(iEvent, iSetup);
+
+  for(const auto& regionSeedingHitSets: seedingHitSets) {
+    const TrackingRegion& region = regionSeedingHitSets.region();
+    seedCreator_.init(region, iSetup, comparitor_.get());
+
+    for(const SeedingHitSet& hits: regionSeedingHitSets) {
+      // TODO: do we really need a comparitor at this point? It is
+      // used in triplet and quadruplet generators, as well as inside
+      // seedCreator.
+      if(!comparitor_ || comparitor_->compatible(hits, region)) {
+        seedCreator_.makeSeed(*seeds, hits);
+      }
+    }
+  }
+
+  seeds->shrink_to_fit();
+  iEvent.put(std::move(seeds));
+}
+
+#endif

--- a/RecoTracker/TkSeedGenerator/plugins/ClusterCheckerEDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/ClusterCheckerEDProducer.cc
@@ -1,0 +1,55 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "RecoTracker/TkSeedGenerator/interface/ClusterChecker.h"
+
+class ClusterCheckerEDProducer: public edm::stream::EDProducer<> {
+public:
+
+  ClusterCheckerEDProducer(const edm::ParameterSet& iConfig);
+  ~ClusterCheckerEDProducer() = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  virtual void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+
+private:
+  ClusterChecker theClusterCheck;
+  bool theSilentOnClusterCheck;
+};
+
+ClusterCheckerEDProducer::ClusterCheckerEDProducer(const edm::ParameterSet& iConfig):
+  theClusterCheck(iConfig, consumesCollector()),
+  theSilentOnClusterCheck(iConfig.getUntrackedParameter<bool>("silentClusterCheck"))
+{
+  produces<bool>();
+}
+
+void ClusterCheckerEDProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  ClusterChecker::fillDescriptions(desc);
+  desc.addUntracked<bool>("silentClusterCheck", false);
+
+  descriptions.add("clusterCheckerEDProducer", desc);
+}
+
+void ClusterCheckerEDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  auto ret = std::make_unique<bool>(true);
+
+  //protection for big ass events...
+  size_t clustsOrZero = theClusterCheck.tooManyClusters(iEvent);
+  if (clustsOrZero){
+    if (!theSilentOnClusterCheck)
+	edm::LogError("TooManyClusters") << "Found too many clusters (" << clustsOrZero << "), bailing out.\n";
+    *ret = false;
+  }
+
+  iEvent.put(std::move(ret));
+}
+
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(ClusterCheckerEDProducer);

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
@@ -166,7 +166,7 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
   vector<const DetLayer *> thirdLayerDetLayer(size,0);
   for (int il=0; il<size; ++il) 
     {
-      thirdHitMap[il] = &(*theLayerCache)(thirdLayers[il], region, ev, es);
+      thirdHitMap[il] = &(*theLayerCache)(thirdLayers[il], region, es);
 
       thirdLayerDetLayer[il] = thirdLayers[il].detLayer();
     }

--- a/RecoTracker/TkSeedGenerator/plugins/SealModules.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SealModules.cc
@@ -28,3 +28,8 @@ DEFINE_EDM_PLUGIN(OrderedHitsGeneratorFactory, CombinedMultiHitGenerator, "Stand
 #include "RecoTracker/TkSeedGenerator/interface/MultiHitGeneratorFromPairAndLayers.h"
 #include "RecoTracker/TkSeedGenerator/interface/MultiHitGeneratorFromPairAndLayersFactory.h"
 DEFINE_EDM_PLUGIN(MultiHitGeneratorFromPairAndLayersFactory, MultiHitGeneratorFromChi2, "MultiHitGeneratorFromChi2");
+
+#include "RecoTracker/TkSeedGenerator/interface/SeedCreatorFromRegionHitsEDProducerT.h"
+#include "SeedFromConsecutiveHitsCreator.h"
+using SeedCreatorFromRegionConsecutiveHitsEDProducer = SeedCreatorFromRegionHitsEDProducerT<SeedFromConsecutiveHitsCreator>;
+DEFINE_FWK_MODULE(SeedCreatorFromRegionConsecutiveHitsEDProducer);

--- a/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.cc
@@ -5,7 +5,8 @@
 #include "RecoTracker/TkSeedGenerator/interface/FastHelix.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include <FWCore/Utilities/interface/ESInputTag.h>
+#include "FWCore/Utilities/interface/ESInputTag.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h" 
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h" 
@@ -23,6 +24,16 @@ namespace {
 }
 
 SeedFromConsecutiveHitsCreator::~SeedFromConsecutiveHitsCreator(){}
+
+void SeedFromConsecutiveHitsCreator::fillDescriptions(edm::ParameterSetDescription& desc) {
+  desc.add<std::string>("propagator", "PropagatorWithMaterialParabolicMf");
+  desc.add<double>("SeedMomentumForBOFF", 5.0);
+  desc.add<double>("OriginTransverseErrorMultiplier", 1.0);
+  desc.add<double>("MinOneOverPtError", 1.0);
+  desc.add<std::string>("TTRHBuilder", "WithTrackAngle");
+  desc.add<std::string>("magneticField", "ParabolicMf");
+  desc.add<bool>("forceKinematicWithRegionDirection", false);
+}
 
 void SeedFromConsecutiveHitsCreator::init(const TrackingRegion & iregion,
 	  const edm::EventSetup& es,

--- a/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.h
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.h
@@ -15,7 +15,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
 #include "DataFormats/TrackingRecHit/interface/mayown_ptr.h"
 
-
+namespace edm { class ParameterSetDescription; }
 class FreeTrajectoryState;
 
 class dso_hidden SeedFromConsecutiveHitsCreator : public SeedCreator {
@@ -33,6 +33,9 @@ public:
 
   //dtor
   virtual ~SeedFromConsecutiveHitsCreator();
+
+  static void fillDescriptions(edm::ParameterSetDescription& desc);
+  static const char *fillDescriptionsLabel() { return "ConsecutiveHits"; }
 
   // initialize the "event dependent state"
   virtual void init(const TrackingRegion & region,

--- a/RecoTracker/TkSeedGenerator/python/clusterCheckerEDProducer_cff.py
+++ b/RecoTracker/TkSeedGenerator/python/clusterCheckerEDProducer_cff.py
@@ -1,0 +1,4 @@
+from Configuration.StandardSequences.Eras import eras
+from RecoTracker.TkSeedGenerator.clusterCheckerEDProducer_cfi import *
+# Disable too many clusters check until we have an updated cut string for phase1
+eras.phase1Pixel.toModify(clusterCheckerEDProducer, doClusterCheck=False) # FIXME

--- a/RecoTracker/TkSeedGenerator/src/ClusterChecker.cc
+++ b/RecoTracker/TkSeedGenerator/src/ClusterChecker.cc
@@ -3,6 +3,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -31,6 +32,15 @@ ClusterChecker::ClusterChecker(const edm::ParameterSet & conf,
             ignoreDetsAboveNClusters_ = 0;
         }
     }
+}
+
+void ClusterChecker::fillDescriptions(edm::ParameterSetDescription& desc) {
+  desc.add<bool>("doClusterCheck", true);
+  desc.add<unsigned>("MaxNumberOfCosmicClusters",  400000);
+  desc.add<edm::InputTag>("ClusterCollectionLabel", edm::InputTag("siStripClusters"));
+  desc.add<unsigned>("MaxNumberOfPixelClusters", 40000);
+  desc.add<edm::InputTag>("PixelClusterCollectionLabel", edm::InputTag("siPixelClusters"));
+  desc.add<std::string>("cut", "strip < 400000 && pixel < 40000 && (strip < 50000 + 10*pixel) && (pixel < 5000 + 0.1*strip)");
 }
 
 

--- a/RecoTracker/TkSeedingLayers/BuildFile.xml
+++ b/RecoTracker/TkSeedingLayers/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="boost"/>
 <use   name="clhep"/>
+<use   name="root"/>
 <use   name="CondFormats/DataRecord"/>
 <use   name="DataFormats/SiPixelDetId"/>
 <use   name="DataFormats/SiStripDetId"/>

--- a/RecoTracker/TkSeedingLayers/src/classes.h
+++ b/RecoTracker/TkSeedingLayers/src/classes.h
@@ -1,0 +1,11 @@
+#include "RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+
+#include <vector>
+
+namespace RecoTracker_TkSeedingLayers {
+  struct dictionary {
+    std::vector<SeedingHitSet> vshs;
+    edm::Wrapper<std::vector<SeedingHitSet> > wvshs;
+  };
+}

--- a/RecoTracker/TkSeedingLayers/src/classes_def.xml
+++ b/RecoTracker/TkSeedingLayers/src/classes_def.xml
@@ -1,0 +1,4 @@
+<lcgdict>
+  <class name="std::vector<SeedingHitSet>" persistent="false"/>
+  <class name="edm::Wrapper<std::vector<SeedingHitSet> >" persistent="false"/>
+</lcgdict>

--- a/RecoTracker/TkTrackingRegions/BuildFile.xml
+++ b/RecoTracker/TkTrackingRegions/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="clhep"/>
 <use   name="boost"/>
+<use   name="root"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/ParameterSet"/>

--- a/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h
@@ -34,7 +34,6 @@ public:
       thePrecise(precise) { }
 
   TrackingRegion::Hits hits(
-      const edm::Event& ev,
       const edm::EventSetup& es,
       const SeedingLayerSetsHits::SeedingLayer& layer) const override;
 

--- a/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
@@ -157,7 +157,6 @@ public:
   bool  isPrecise() const { return thePrecise; }
 
   virtual TrackingRegion::Hits hits(
-      const edm::Event& ev,
       const edm::EventSetup& es,
       const SeedingLayerSetsHits::SeedingLayer& layer) const override;
 

--- a/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h
@@ -96,9 +96,7 @@ public:
 
 
 /// get hits from layer compatible with region constraints 
-  virtual Hits hits(
-		    const edm::Event& ev,
-		    const edm::EventSetup& es,
+  virtual Hits hits(const edm::EventSetup& es,
 		    const SeedingLayerSetsHits::SeedingLayer& layer) const = 0;
   
   /// clone region with new vertex position

--- a/RecoTracker/TkTrackingRegions/interface/TrackingRegionEDProducerT.h
+++ b/RecoTracker/TkTrackingRegions/interface/TrackingRegionEDProducerT.h
@@ -1,0 +1,45 @@
+#ifndef RecoTracker_TkTrackingRegions_TrackingRegionEDProducerT_H
+#define RecoTracker_TkTrackingRegions_TrackingRegionEDProducerT_H
+
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
+#include "DataFormats/Common/interface/OwnVector.h"
+
+template <typename T_TrackingRegionProducer>
+class TrackingRegionEDProducerT: public edm::stream::EDProducer<> {
+public:
+  // using OwnVector as vector<shared_ptr> and vector<unique_ptr> cause problems
+  // I can't get dictionary compiled with unique_ptr
+  // shared_ptr fails with runtime error "Class name 'TrackingRegionstdshared_ptrs' contains an underscore ('_'), which is illegal in the name of a product."
+  using ProductType = edm::OwnVector<TrackingRegion>;
+
+  TrackingRegionEDProducerT(const edm::ParameterSet& iConfig):
+    regionProducer_(iConfig, consumesCollector()) {
+    produces<ProductType>();
+  }
+
+  ~TrackingRegionEDProducerT() = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    T_TrackingRegionProducer::fillDescriptions(descriptions);
+  }
+
+  virtual void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override {
+    auto regions = regionProducer_.regions(iEvent, iSetup);
+    auto ret = std::make_unique<ProductType>();
+    ret->reserve(regions.size());
+    for(auto& regionPtr: regions) {
+      ret->push_back(regionPtr.release());
+    }
+
+    iEvent.put(std::move(ret));
+  }
+
+private:
+  T_TrackingRegionProducer regionProducer_;
+};
+
+#endif

--- a/RecoTracker/TkTrackingRegions/plugins/GlobalTrackingRegionProducerFromBeamSpot.h
+++ b/RecoTracker/TkTrackingRegions/plugins/GlobalTrackingRegionProducerFromBeamSpot.h
@@ -4,6 +4,8 @@
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducer.h"
 #include "RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/Exception.h"
@@ -35,6 +37,42 @@ public:
   }
 
   virtual ~GlobalTrackingRegionProducerFromBeamSpot(){}
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    {
+      edm::ParameterSetDescription desc;
+
+      desc.add<bool>("precise", true);
+      desc.add<bool>("useMultipleScattering", false);
+      desc.add<double>("nSigmaZ", 4.0);
+      desc.add<double>("originRadius", 0.2);
+      desc.add<double>("ptMin", 0.9);
+      desc.add<edm::InputTag>("beamSpot", edm::InputTag("offlineBeamSpot"));
+
+      // Only for backwards-compatibility
+      edm::ParameterSetDescription descRegion;
+      descRegion.add<edm::ParameterSetDescription>("RegionPSet", desc);
+
+      descriptions.add("globalTrackingRegionFromBeamSpot", descRegion);
+    }
+
+    {
+      edm::ParameterSetDescription desc;
+
+      desc.add<bool>("precise", true);
+      desc.add<bool>("useMultipleScattering", false);
+      desc.add<double>("originHalfLength", 21.2);
+      desc.add<double>("originRadius", 0.2);
+      desc.add<double>("ptMin", 0.9);
+      desc.add<edm::InputTag>("beamSpot", edm::InputTag("offlineBeamSpot"));
+
+      // Only for backwards-compatibility
+      edm::ParameterSetDescription descRegion;
+      descRegion.add<edm::ParameterSetDescription>("RegionPSet", desc);
+
+      descriptions.add("globalTrackingRegionFromBeamSpotFixedZ", descRegion);
+    }
+  }
 
   virtual std::vector<std::unique_ptr<TrackingRegion> > regions(const edm::Event&ev, const edm::EventSetup&) const override {
     std::vector<std::unique_ptr<TrackingRegion> > result;

--- a/RecoTracker/TkTrackingRegions/plugins/SealModule.cc
+++ b/RecoTracker/TkTrackingRegions/plugins/SealModule.cc
@@ -16,3 +16,6 @@ DEFINE_EDM_PLUGIN(TrackingRegionProducerFactory, GlobalTrackingRegionWithVertice
 DEFINE_EDM_PLUGIN(TrackingRegionProducerFactory, PointSeededTrackingRegionsProducer, "PointSeededTrackingRegionsProducer");
 
 
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegionEDProducerT.h"
+using GlobalTrackinRegionFromBeamSpotEDProducer = TrackingRegionEDProducerT<GlobalTrackingRegionProducerFromBeamSpot>;
+DEFINE_FWK_MODULE(GlobalTrackinRegionFromBeamSpotEDProducer);

--- a/RecoTracker/TkTrackingRegions/src/GlobalTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/GlobalTrackingRegion.cc
@@ -25,7 +25,6 @@ std::string GlobalTrackingRegion::print() const {
 }
 
 TrackingRegion::Hits GlobalTrackingRegion::hits(
-      const edm::Event& ev,
       const edm::EventSetup& es,
       const SeedingLayerSetsHits::SeedingLayer& layer) const {
   return layer.hits();

--- a/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
@@ -300,7 +300,6 @@ HitRZConstraint
 }
 
 TrackingRegion::Hits RectangularEtaPhiTrackingRegion::hits(
-      const edm::Event& ev,
       const edm::EventSetup& es,
       const SeedingLayerSetsHits::SeedingLayer& layer) const {
   TrackingRegion::Hits result;

--- a/RecoTracker/TkTrackingRegions/src/classes.h
+++ b/RecoTracker/TkTrackingRegions/src/classes.h
@@ -1,0 +1,10 @@
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
+#include "DataFormats/Common/interface/OwnVector.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+
+namespace RecoTracker_TkTrackingRegions {
+  struct dictionary {
+    edm::OwnVector<TrackingRegion> ovtr;
+    edm::Wrapper<edm::OwnVector<TrackingRegion> > wovtr;
+  };
+}

--- a/RecoTracker/TkTrackingRegions/src/classes_def.xml
+++ b/RecoTracker/TkTrackingRegions/src/classes_def.xml
@@ -1,0 +1,4 @@
+<lcgdict>
+  <class name="edm::OwnVector<TrackingRegion>" persistent="false"/>
+  <class name="edm::Wrapper<edm::OwnVector<TrackingRegion> >" persistent="false"/>
+</lcgdict>

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -190,16 +190,28 @@ def _setForEra(module, era, **kwargs):
 def _getSeedingLayers(seedProducers):
     import RecoTracker.IterativeTracking.iterativeTk_cff as _iterativeTk_cff
 
+    def _findDoubletProducer(name):
+        prod = getattr(_iterativeTk_cff, name)
+        if hasattr(prod, "triplets"):
+            return _findDoubletProducer(prod.triplets.getModuleLabel())
+        elif hasattr(prod, "doublets"):
+            return _findDoubletProducer(prod.doublets.getModuleLabel())
+        return prod
+
     seedingLayersMerged = []
     for seedName in seedProducers:
         seedProd = getattr(_iterativeTk_cff, seedName)
-        if not hasattr(seedProd, "OrderedHitsFactoryPSet"):
+        if hasattr(seedProd, "OrderedHitsFactoryPSet"):
+            if hasattr(seedProd, "SeedMergerPSet"):
+                seedingLayersName = seedProd.SeedMergerPSet.layerList.refToPSet_.value()
+            else:
+                seedingLayersName = seedProd.OrderedHitsFactoryPSet.SeedingLayers.getModuleLabel()
+        elif hasattr(seedProd, "seedingHitSets"):
+            doubletProd = _findDoubletProducer(seedProd.seedingHitSets.getModuleLabel())
+            seedingLayersName = doubletProd.seedingLayers.getModuleLabel()
+        else:
             continue
 
-        if hasattr(seedProd, "SeedMergerPSet"):
-            seedingLayersName = seedProd.SeedMergerPSet.layerList.refToPSet_.value()
-        else:
-            seedingLayersName = seedProd.OrderedHitsFactoryPSet.SeedingLayers.getModuleLabel()
         seedingLayers = getattr(_iterativeTk_cff, seedingLayersName).layerList.value()
         for layerSet in seedingLayers:
             if layerSet not in seedingLayersMerged:


### PR DESCRIPTION
@rovere @VinInn @mtosi @felicepantaleo @ebrondol
I use the github PR mechanism (against my personal cmssw repository) for easy commenting.

This branch contains a first prototype of the seeding framework refactoring I've been working on. It is complete in the sense that it works for InitialStep-like quadruplet seeding, but otherwise it is incomplete (see also down below). But I think at this point it would be useful to show it and get feedback. Consider this as a preview, and please comment if you see any problems with the approach. I won't specifically wait for comments for further developments needed for a PR (see a list further below), but if anything shows up before, I could fix it already before.
## Summary

In short, this branch takes the regions, cluster check, doublet generation, triplet generation, and quadruplet generation out of the seed generator, and makes each of them an `EDProducer`. The information between the modules is delivered via `edm::Event`.

My aim is to keep the changes purely technical (to ease integration). For demonstration and testing purposes I've converted `InitialStepPreSplitting` to use the new-style seeding.  With `runTheMatrix.py` I see no changes in RECO (also with `trackingOnly` monitoring, which includes seeds and built tracks from `InitialStepPreSplitting`), but when running HLT in step2 with the customization included here, I do see some small differences. I don't fully understand them yet (possibly related to `maxElement` parameters), but obviously they need to be fixed before a PR.
- Pros
  - Much (infinitively?) more flexible
  - Supports `fillDescriptions`
    - `SeedComparitor` remains to be used as "helper plugin" and thus is not fully `fillDescriptions` compliant. As discussed earlier @felicepantaleo, we think the current `SeedComparitor` class hierarchy is complex, confusing, and could be made faster, and so it is better left as a full re-engineering exercise later.
  - Non-repetition of doublet generation comes out of the box for quadruplet seeding
    - CA (but only in private version IIRC?) has already some bookkeeping to avoid, but with this branch there would be no need to bookkeep
    - In "propagation quadruplets" the time spent in doublets is small, O(5%), but an improvement is an improvement
- Cons
  - The data structures delivering all information from doublet generation to triplet generation (`IntermediateHitDoublets`), and from triplet generation to quadruplet generation (`IntermediateHitTriplets`) are quite complex
    - Some of the complexity is caused by the desire to keep results unchanged, and some from the current computation structures. I believe with further refactoring they could be simplified.
  - More modules to manage in configuration

@felicepantaleo In this preview I've only migrated "propagation quadruplets" to the new framework. Note that while I templated the EDProducer for triplets, I did not use templates for quadruplets. The reason is that the interfaces of `PixelQuadrupletGenerator` and `CAHitQuadrupletGenerator` are different and hence they need different glue between them and `Event`. With its own EDProducer it should be straightforward to modify `CAHitQuadrupletGenerator` to first fill the CA with all doublets, and then loop over the regions (following the earlier discussion).

@mtosi Do you foresee any problems regarding HLT and ConfDB?

@ebrondol I'd suggest to wait these changes to be merged before "rebasing" phase2 tracking on top of latest "phase1" (I don't know how soon you have been planning to work on it, but thought to warn explicitly)
### Correspondence with classes of the current seeding framework

Some correspondence between the new and current classes can be drawn based on their functionality
- `TrackingRegionTEDProducerT<T>` corresponds roughly `TrackingRegionProducerFactory`
- `HitTripletEDProducerT<T>` corresponds roughly `CombinedHitTripletGenerator` and `HitTripletGeneratorFromPairAndLayersFactory`
- `SeedCreatorFromRegionHitsEDProducerT<T>` corresponds roughly `SeedGeneratorFromRegionHitsEDProducer`, `SeedGeneratorFromRegionHits`, and `SeedCreatorFactory`
## TODO for PR

I'd expect to finish within a week (but depends a lot of other work).
- [x] Unify interfaces etc
- [x] Add all modules needed by iterative tracking (all flavours, run2, phase1, phase2 etc)
  - Unfortunately this also means the old-style quadruplet seeding by triplet merging (mixture of current and proposed seeding, customized with era, would require even more effort)
  - Also including the CA quadruplets, update the customize to keep it working
- [x] More thorough testing with more events than in `runTheMatrix.py`
  - [x] Also including performance comparison
- [x] Understand and fix the cause for small changes in HLT
- [x] Document the internals of `IntermediateHitDoublets` and `IntermediateHitTriplets`
## Short-term next steps (soon after PR)
- [x] Add modules needed by HLT, add proper customization to `customizeHLTforCMSSW.py`
  - [x] Including pixel tracks
- [ ] Optimize data structures, especially the use of `LayerHitMapCache`
  - [ ] Consider producing `LayerHitMapCache`'s already by `SeedingLayersEDProducer`
## Longer-term next steps
- [ ] If anything is left, migrate them (or remove if obsolete)
- [ ] Address `SeedComparitor`s
- [ ] Cleanup, i.e. removal of the old framework (not before 81X+1, maybe leave to 81X+2 to play safe)
