### PR TITLE
Fix a memory leak

### DIFF
--- a/CUDADataFormats/PortableTestObjects/src/classes_def.xml
+++ b/CUDADataFormats/PortableTestObjects/src/classes_def.xml
@@ -5,7 +5,7 @@
     targetClass="cudatest::TestHostCollection"
     version="[1-]"
     source="portabletest::TestSoA layout_;"
-    target="buffer_,layout_"
+    target="buffer_,layout_,view_"
     embed="false">
   <![CDATA[
     cudatest::TestHostCollection::ROOTReadStreamer(newObj, onfile.layout_);

--- a/DataFormats/Portable/interface/PortableHostCollection.h
+++ b/DataFormats/Portable/interface/PortableHostCollection.h
@@ -68,11 +68,12 @@ public:
   ConstBuffer const_buffer() const { return *buffer_; }
 
   // part of the ROOT read streamer
-  static void ROOTReadStreamer(PortableHostCollection* newObj, Layout const& layout) {
+  static void ROOTReadStreamer(PortableHostCollection* newObj, Layout& layout) {
     newObj->~PortableHostCollection();
     // use the global "host" object returned by cms::alpakatools::host()
     new (newObj) PortableHostCollection(layout.metadata().size(), cms::alpakatools::host());
     newObj->layout_.ROOTReadStreamer(layout);
+    layout.ROOTStreamerCleaner();
   }
 
 private:

--- a/DataFormats/PortableTestObjects/src/alpaka/classes_serial_def.xml
+++ b/DataFormats/PortableTestObjects/src/alpaka/classes_serial_def.xml
@@ -5,7 +5,7 @@
     targetClass="portabletest::TestHostCollection"
     version="[1-]"
     source="portabletest::TestSoA layout_;"
-    target="buffer_,layout_"
+    target="buffer_,layout_,view_"
     embed="false">
   <![CDATA[
     portabletest::TestHostCollection::ROOTReadStreamer(newObj, onfile.layout_);

--- a/DataFormats/SoATemplate/interface/SoALayout.h
+++ b/DataFormats/SoATemplate/interface/SoALayout.h
@@ -267,6 +267,17 @@
 #define _VALUE_ELEMENT_INITIALIZERS(R, DATA, TYPE_NAME) BOOST_PP_EXPAND(_VALUE_ELEMENT_INITIALIZERS_IMPL TYPE_NAME)
 
 /**
+ * Freeing of the ROOT-allocated column or scalar buffer
+ */
+// clang-format off
+#define _ROOT_FREE_SOA_COLUMN_OR_SCALAR_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                                  \
+  delete[] BOOST_PP_CAT(NAME, _); \
+  BOOST_PP_CAT(NAME, _) = nullptr; \
+// clang-format on
+
+#define _ROOT_FREE_SOA_COLUMN_OR_SCALAR(R, DATA, TYPE_NAME) _ROOT_FREE_SOA_COLUMN_OR_SCALAR_IMPL TYPE_NAME
+
+/**
  * Computation of the column or scalar pointer location in the memory layout (at SoA construction time)
  */
 // clang-format off
@@ -561,6 +572,12 @@
     void ROOTReadStreamer(T & onfile) {                                                                                \
       auto size = onfile.metadata().size();                                                                            \
       _ITERATE_ON_ALL(_STREAMER_READ_SOA_DATA_MEMBER, ~, __VA_ARGS__)                                                  \
+    }                                                                                                                  \
+                                                                                                                       \
+    /* ROOT allocation cleanup */                                                                                      \
+    void ROOTStreamerCleaner() {                                                                                       \
+      /* This function should only be called from the PortableCollection ROOT streamer */                              \
+      _ITERATE_ON_ALL(_ROOT_FREE_SOA_COLUMN_OR_SCALAR, ~, __VA_ARGS__)                                                 \
     }                                                                                                                  \
                                                                                                                        \
     /* Dump the SoA internal structure */                                                                              \


### PR DESCRIPTION
This commit adds freeing of memory allocated by ROOT during streaming from disk. It also declares all members of PortableHostCollections as target (as the streamer fill them all up).